### PR TITLE
refactor(rename): 'infer_schema' to 'infer_json_schema'

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -248,7 +248,7 @@ py-quick:
     print('Input DataFrame:')
     print(df)
     
-    schema = df.genson.infer_schema('json_data')
+    schema = df.genson.infer_json_schema('json_data')
     print('\nInferred schema:')
     print(json.dumps(schema, indent=2))
     

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ shape: (3, 1)
 
 ```python
 # Infer schema from the JSON column using the genson namespace
-schema = df.genson.infer_schema("json_data")
+schema = df.genson.infer_json_schema("json_data")
 
 print("Inferred schema:")
 print(json.dumps(schema, indent=2))
@@ -115,7 +115,7 @@ result = df.select(
 )
 
 # Or use with different options
-schema = df.genson.infer_schema(
+schema = df.genson.infer_json_schema(
     "json_data",
     ignore_outer_array=False,  # Treat top-level arrays as arrays
     ndjson=True,              # Handle newline-delimited JSON

--- a/genson-core/src/lib.rs
+++ b/genson-core/src/lib.rs
@@ -4,14 +4,14 @@ compile_error!("genson-core requires panic=unwind to catch genson-rs panics. Set
 pub mod schema;
 
 // Re-export commonly used items
-pub use schema::{infer_schema_from_strings, SchemaInferenceConfig, SchemaInferenceResult};
+pub use schema::{infer_json_schema_from_strings, SchemaInferenceConfig, SchemaInferenceResult};
 
 /// Helper function to infer JSON schema from a collection of JSON strings
 pub fn infer_json_schema(
     json_strings: &[String],
     config: Option<SchemaInferenceConfig>,
 ) -> Result<SchemaInferenceResult, String> {
-    infer_schema_from_strings(json_strings, config.unwrap_or_default())
+    infer_json_schema_from_strings(json_strings, config.unwrap_or_default())
 }
 
 /// Create a default schema inference configuration

--- a/genson-core/src/schema.rs
+++ b/genson-core/src/schema.rs
@@ -51,7 +51,7 @@ fn validate_ndjson(s: &str) -> Result<(), serde_json::Error> {
 }
 
 /// Infer JSON schema from a collection of JSON strings
-pub fn infer_schema_from_strings(
+pub fn infer_json_schema_from_strings(
     json_strings: &[String],
     config: SchemaInferenceConfig,
 ) -> Result<SchemaInferenceResult, String> {
@@ -151,7 +151,7 @@ mod tests {
             r#"{"name": "Bob", "age": 25, "city": "NYC"}"#.to_string(),
         ];
 
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
             .expect("Schema inference should succeed");
 
         // Test processed count
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn test_empty_input() {
         let json_strings = vec![];
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
         assert!(result.is_err());
 
@@ -223,7 +223,7 @@ mod tests {
 
             let json_strings = vec![valid_json.to_string(), invalid_json.to_string()];
 
-            let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+            let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
             // Should return an error instead of panicking
             assert!(result.is_err(), "Expected error for case: {}", description);
@@ -260,7 +260,7 @@ mod tests {
             r#"{"name": "Bob", "age": 25}"#.to_string(),
         ];
 
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
             .expect("Should succeed with valid JSON, skipping empty strings");
 
         // Should process only the 2 valid JSON strings
@@ -287,7 +287,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = infer_schema_from_strings(&json_strings, config_array)
+        let result = infer_json_schema_from_strings(&json_strings, config_array)
             .expect("Should handle array schema");
 
         let schema_str = result.schema.to_string();
@@ -306,7 +306,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = infer_schema_from_strings(&json_strings, config_object)
+        let result = infer_json_schema_from_strings(&json_strings, config_object)
             .expect("Should handle object schema from array items");
 
         let schema_str = result.schema.to_string();
@@ -341,7 +341,7 @@ mod tests {
             long_invalid_json.len()
         );
 
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
         assert!(result.is_err(), "Expected error for very long invalid JSON");
 
@@ -407,7 +407,7 @@ mod tests {
             .to_string(),
         ];
 
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default())
             .expect("Should handle complex nested schema");
 
         assert_eq!(result.processed_count, 2);
@@ -444,7 +444,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = infer_schema_from_strings(&json_strings, config)
+        let result = infer_json_schema_from_strings(&json_strings, config)
             .expect("NDJSON schema inference should succeed");
 
         // All 3 objects should be processed
@@ -482,7 +482,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = infer_schema_from_strings(&json_strings, config);
+        let result = infer_json_schema_from_strings(&json_strings, config);
 
         assert!(result.is_err(), "Expected error for malformed NDJSON line");
 

--- a/genson-core/tests/integration.rs
+++ b/genson-core/tests/integration.rs
@@ -1,4 +1,4 @@
-use genson_core::{infer_schema_from_strings, SchemaInferenceConfig};
+use genson_core::{infer_json_schema_from_strings, SchemaInferenceConfig};
 
 #[test]
 fn test_invalid_json_integration() {
@@ -20,7 +20,7 @@ fn test_invalid_json_integration() {
         let json_strings = vec![invalid_json.to_string()];
 
         // This should NOT panic - it should return a proper error
-        let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+        let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
         match result {
             Ok(schema_result) => {
@@ -56,7 +56,7 @@ fn test_mixed_valid_and_invalid_json() {
     ];
 
     // This should handle the invalid JSON gracefully
-    let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+    let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
     // Should either:
     // 1. Return an error (preferred)
@@ -91,7 +91,7 @@ fn test_only_invalid_json() {
         r#"{"also": invalid}"#.to_string(),
     ];
 
-    let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+    let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
     // Should definitely return an error
     assert!(result.is_err(), "Should return error for all invalid JSON");

--- a/genson-core/tests/verify.rs
+++ b/genson-core/tests/verify.rs
@@ -1,11 +1,11 @@
-use genson_core::{infer_schema_from_strings, SchemaInferenceConfig};
+use genson_core::{infer_json_schema_from_strings, SchemaInferenceConfig};
 
 #[test]
 fn test_single_invalid_json_honest() {
     println!("Testing invalid JSON: {{\"invalid\": json}}");
 
     let json_strings = vec![r#"{"invalid": json}"#.to_string()];
-    let result = infer_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
+    let result = infer_json_schema_from_strings(&json_strings, SchemaInferenceConfig::default());
 
     match result {
         Ok(schema_result) => {

--- a/polars-genson-py/debug_test_script.py
+++ b/polars-genson-py/debug_test_script.py
@@ -28,9 +28,9 @@ try:
         print("   ✗ genson namespace NOT found")
         exit(1)
 
-    print("5. Calling infer_schema with debug...")
+    print("5. Calling infer_json_schema with debug...")
     try:
-        schema = df.genson.infer_schema("json_data", debug=True)
+        schema = df.genson.infer_json_schema("json_data", debug=True)
         print("   ✓ Schema inference completed!")
         print(f"   Schema type: {type(schema)}")
 

--- a/polars-genson-py/python/polars_genson/__init__.py
+++ b/polars-genson-py/python/polars_genson/__init__.py
@@ -85,7 +85,7 @@ class GensonNamespace:
     def __init__(self, df: pl.DataFrame):
         self._df = df
 
-    def infer_schema(
+    def infer_json_schema(
         self,
         column: str,
         *,

--- a/polars-genson-py/python/polars_genson/__init__.pyi
+++ b/polars-genson-py/python/polars_genson/__init__.pyi
@@ -18,7 +18,7 @@ def infer_json_schema(
 
 class GensonNamespace:
     def __init__(self, df: pl.DataFrame) -> None: ...
-    def infer_schema(
+    def infer_json_schema(
         self,
         column: str,
         *,

--- a/polars-genson-py/src/expressions.rs
+++ b/polars-genson-py/src/expressions.rs
@@ -1,4 +1,4 @@
-use genson_core::{infer_schema_from_strings, SchemaInferenceConfig};
+use genson_core::{infer_json_schema_from_strings, SchemaInferenceConfig};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use serde::Deserialize;
@@ -84,7 +84,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
                 schema_uri: kwargs.schema_uri.clone(),
             };
 
-            let schema_result = infer_schema_from_strings(&json_strings, config)
+            let schema_result = infer_json_schema_from_strings(&json_strings, config)
                 .map_err(|e| format!("Genson error: {}", e))?;
 
             serde_json::to_string_pretty(&schema_result.schema)
@@ -119,7 +119,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
                     schema_uri: kwargs.schema_uri.clone(),
                 };
 
-                let single_result = infer_schema_from_strings(&[json_str.clone()], config)
+                let single_result = infer_json_schema_from_strings(&[json_str.clone()], config)
                     .map_err(|e| format!("Individual genson error: {}", e))?;
                 individual_schemas.push(single_result.schema);
             }

--- a/polars-genson-py/tests/array_handling_test.py
+++ b/polars-genson-py/tests/array_handling_test.py
@@ -15,7 +15,7 @@ def test_ignore_outer_array_true():
         }
     )
 
-    schema = df.genson.infer_schema("json_data", ignore_outer_array=True)
+    schema = df.genson.infer_json_schema("json_data", ignore_outer_array=True)
 
     # Should treat array elements as individual objects
     assert isinstance(schema, dict)
@@ -37,7 +37,7 @@ def test_ignore_outer_array_false():
         }
     )
 
-    schema = df.genson.infer_schema("json_data", ignore_outer_array=False)
+    schema = df.genson.infer_json_schema("json_data", ignore_outer_array=False)
 
     # Should treat arrays as arrays, not flatten them
     assert isinstance(schema, dict)
@@ -55,7 +55,7 @@ def test_ndjson_format():
         }
     )
 
-    schema = df.genson.infer_schema("json_data", debug=True, ndjson=True)
+    schema = df.genson.infer_json_schema("json_data", debug=True, ndjson=True)
 
     assert isinstance(schema, dict)
     assert "properties" in schema
@@ -78,7 +78,7 @@ def test_mixed_json_formats():
     )
 
     # With ignore_outer_array=True, should handle mixed formats
-    schema = df.genson.infer_schema("json_data", ignore_outer_array=True)
+    schema = df.genson.infer_json_schema("json_data", ignore_outer_array=True)
 
     assert isinstance(schema, dict)
     assert "properties" in schema
@@ -89,7 +89,7 @@ def test_empty_arrays():
     df = pl.DataFrame({"json_data": ["[]", '{"valid": "object"}']})
 
     # Should handle empty arrays gracefully
-    schema = df.genson.infer_schema("json_data")
+    schema = df.genson.infer_json_schema("json_data")
 
     assert isinstance(schema, dict)
 
@@ -105,7 +105,7 @@ def test_nested_arrays():
         }
     )
 
-    schema = df.genson.infer_schema("json_data")
+    schema = df.genson.infer_json_schema("json_data")
 
     assert isinstance(schema, dict)
     assert "properties" in schema

--- a/polars-genson-py/tests/core_test.py
+++ b/polars-genson-py/tests/core_test.py
@@ -12,7 +12,7 @@ def test_namespace_registration():
     """Test that the genson namespace is registered on DataFrames."""
     df = pl.DataFrame({"test": ["data"]})
     assert hasattr(df, "genson")
-    assert hasattr(df.genson, "infer_schema")
+    assert hasattr(df.genson, "infer_json_schema")
 
 
 def test_basic_schema_inference():
@@ -28,7 +28,7 @@ def test_basic_schema_inference():
     )
 
     # Infer schema using the namespace
-    schema = df.genson.infer_schema("json_data")
+    schema = df.genson.infer_json_schema("json_data")
 
     # Verify schema structure
     assert isinstance(schema, dict)
@@ -52,7 +52,7 @@ def test_empty_column():
     df = pl.DataFrame({"json_data": []})
 
     with raises(Exception):  # Should raise an error for empty input
-        df.genson.infer_schema("json_data")
+        df.genson.infer_json_schema("json_data")
 
 
 def test_null_values():
@@ -67,7 +67,7 @@ def test_null_values():
         }
     )
 
-    schema = df.genson.infer_schema("json_data")
+    schema = df.genson.infer_json_schema("json_data")
 
     # Should work despite null values
     assert isinstance(schema, dict)
@@ -119,7 +119,7 @@ def test_invalid_json():
 
     # Should handle invalid JSON gracefully or raise appropriate error
     with raises(Exception):
-        df.genson.infer_schema("json_data")
+        df.genson.infer_json_schema("json_data")
 
 
 def test_invalid_ndjson_format():
@@ -135,7 +135,7 @@ def test_invalid_ndjson_format():
 
     # Should raise an error due to invalid JSON on the second line of first string
     with raises(Exception) as exc_info:
-        df.genson.infer_schema("json_data", ndjson=True)
+        df.genson.infer_json_schema("json_data", ndjson=True)
 
     # Verify the error message contains information about the invalid JSON
     error_message = str(exc_info.value)
@@ -147,4 +147,4 @@ def test_non_string_column():
     df = pl.DataFrame({"numbers": [1, 2, 3]})
 
     with raises(Exception):
-        df.genson.infer_schema("numbers")
+        df.genson.infer_json_schema("numbers")

--- a/polars-genson-py/tests/merge_schemas_test.py
+++ b/polars-genson-py/tests/merge_schemas_test.py
@@ -17,7 +17,7 @@ def test_merge_schemas_true():
         }
     )
 
-    schema = df.genson.infer_schema("json_data", merge_schemas=True)
+    schema = df.genson.infer_json_schema("json_data", merge_schemas=True)
 
     # Should return a single merged schema
     assert isinstance(schema, dict)
@@ -43,7 +43,7 @@ def test_merge_schemas_false():
         }
     )
 
-    schemas = df.genson.infer_schema("json_data", merge_schemas=False)
+    schemas = df.genson.infer_json_schema("json_data", merge_schemas=False)
 
     # Should return a list of individual schemas
     assert isinstance(schemas, list)
@@ -85,10 +85,10 @@ def test_concordant_vs_discordant():
     )
 
     # Test concordant schemas
-    concordant_merged = concordant_df.genson.infer_schema(
+    concordant_merged = concordant_df.genson.infer_json_schema(
         "json_data", merge_schemas=True
     )
-    concordant_individual = concordant_df.genson.infer_schema(
+    concordant_individual = concordant_df.genson.infer_json_schema(
         "json_data", merge_schemas=False
     )
 
@@ -100,10 +100,10 @@ def test_concordant_vs_discordant():
     assert len(concordant_individual) == 3
 
     # Test discordant schemas
-    discordant_merged = discordant_df.genson.infer_schema(
+    discordant_merged = discordant_df.genson.infer_json_schema(
         "json_data", merge_schemas=True
     )
-    discordant_individual = discordant_df.genson.infer_schema(
+    discordant_individual = discordant_df.genson.infer_json_schema(
         "json_data", merge_schemas=False
     )
 

--- a/polars-jsonschema-bridge/src/lib.rs
+++ b/polars-jsonschema-bridge/src/lib.rs
@@ -223,15 +223,6 @@ pub fn json_schema_to_polars_dtype(json_schema: &Value) -> Result<DataType> {
             let inner_dtype = json_schema_to_polars_dtype(items_schema)?;
 
             // Check if it's a fixed-size array
-            if let (Some(min_items), Some(max_items)) = (
-                json_schema.get("minItems").and_then(|m| m.as_u64()),
-                json_schema.get("maxItems").and_then(|m| m.as_u64()),
-            ) {
-                if min_items == max_items {
-                    return Ok(DataType::Array(Box::new(inner_dtype), min_items as usize));
-                }
-            }
-
             Ok(DataType::List(Box::new(inner_dtype)))
         }
 


### PR DESCRIPTION
Will need separate methods for inferring polars schema directly (will also be able to convert between them but for efficiency will want to go directly without passing the computed JSON Schema strings back over the Rust-Python channel to get them as Polars schemas)