### PR TITLE
refactor: show the default schema URI to Python users

### DIFF
--- a/polars-genson-py/README.md
+++ b/polars-genson-py/README.md
@@ -169,9 +169,9 @@ result = df.select(
 schema = df.genson.infer_json_schema(
     "json_data",
     ignore_outer_array=False,  # Treat top-level arrays as arrays
-    ndjson=True,              # Handle newline-delimited JSON
-    schema_uri="AUTO",        # Specify a schema URI
-    merge_schemas=True        # Merge all schemas (default)
+    ndjson=True,               # Handle newline-delimited JSON
+    schema_uri="https://json-schema.org/draft/2020-12/schema",  # Specify a schema URI
+    merge_schemas=True         # Merge all schemas (default)
 )
 ```
 

--- a/polars-genson-py/python/polars_genson/__init__.py
+++ b/polars-genson-py/python/polars_genson/__init__.py
@@ -41,7 +41,7 @@ def infer_json_schema(
     *,
     ignore_outer_array: bool = True,
     ndjson: bool = False,
-    schema_uri: str | None = "AUTO",
+    schema_uri: str | None = "http://json-schema.org/schema#",
     merge_schemas: bool = True,
     debug: bool = False,
 ) -> pl.Expr:
@@ -55,8 +55,8 @@ def infer_json_schema(
         Whether to treat top-level arrays as streams of objects
     ndjson : bool, default False
         Whether to treat input as newline-delimited JSON
-    schema_uri : str or None, default "AUTO"
-        Schema URI to use for the generated schema ("AUTO" for auto-detection)
+    schema_uri : str or None, default "http://json-schema.org/schema#"
+        Schema URI to use for the generated schema
     merge_schemas : bool, default True
         Whether to merge schemas from all rows (True) or return individual schemas (False)
     debug : bool, default False
@@ -181,7 +181,7 @@ class GensonNamespace:
         *,
         ignore_outer_array: bool = True,
         ndjson: bool = False,
-        schema_uri: str | None = "AUTO",
+        schema_uri: str | None = "http://json-schema.org/schema#",
         merge_schemas: bool = True,
         debug: bool = False,
     ) -> dict | list[dict]:
@@ -195,8 +195,8 @@ class GensonNamespace:
             Whether to treat top-level arrays as streams of objects
         ndjson : bool, default False
             Whether to treat input as newline-delimited JSON
-        schema_uri : str or None, default "AUTO"
-            Schema URI to use for the generated schema ("AUTO" for auto-detection)
+        schema_uri : str or None, default "http://json-schema.org/schema#"
+            Schema URI to use for the generated schema
         merge_schemas : bool, default True
             Whether to merge schemas from all rows (True) or return individual schemas (False)
         debug : bool, default False

--- a/polars-genson-py/python/polars_genson/__init__.pyi
+++ b/polars-genson-py/python/polars_genson/__init__.pyi
@@ -11,7 +11,7 @@ def infer_json_schema(
     *,
     ignore_outer_array: bool = True,
     ndjson: bool = False,
-    schema_uri: str | None = "AUTO",
+    schema_uri: str | None = "http://json-schema.org/schema#",
     merge_schemas: bool = True,
     debug: bool = False,
 ) -> pl.Expr: ...
@@ -24,7 +24,7 @@ class GensonNamespace:
         *,
         ignore_outer_array: bool = True,
         ndjson: bool = False,
-        schema_uri: str | None = "AUTO",
+        schema_uri: str | None = "http://json-schema.org/schema#",
         merge_schemas: bool = True,
         debug: bool = False,
     ) -> dict[str, Any] | list[dict[str, Any]]: ...

--- a/polars-genson-py/tests/schema_uri_test.py
+++ b/polars-genson-py/tests/schema_uri_test.py
@@ -1,0 +1,37 @@
+"""Tests for schema_uri parameter handling."""
+
+import polars as pl
+import polars_genson  # noqa: F401
+from pytest import mark
+
+
+def test_schema_uri_default_auto():
+    """Test that schema_uri default produces generic schema URI."""
+    df = pl.DataFrame({"json_data": ['{"name": "Alice", "age": 30}']})
+
+    # Default behavior (schema_uri=None)
+    schema = df.genson.infer_json_schema("json_data")
+
+    # Should have a proper $schema URI starting with http
+    assert "$schema" in schema
+    assert schema["$schema"] == "http://json-schema.org/schema#"
+
+
+def test_schema_uri_explicit_none():
+    """Test explicit schema_uri=None omits schema URI."""
+    df = pl.DataFrame({"json_data": ['{"name": "Alice", "age": 30}']})
+
+    schema = df.genson.infer_json_schema("json_data", schema_uri=None)
+
+    # Should have a proper $schema URI starting with http
+    assert "$schema" not in schema
+
+
+def test_schema_uri_custom_string():
+    """Test custom schema_uri string."""
+    df = pl.DataFrame({"json_data": ['{"name": "Alice", "age": 30}']})
+
+    custom_uri = "https://example.com/my-schema"
+    schema = df.genson.infer_json_schema("json_data", schema_uri=custom_uri)
+
+    assert schema["$schema"] == custom_uri


### PR DESCRIPTION
The AUTO default is used Rust side (genson-core) but it doesn't hurt to use an explicit default of what that
resolves to in reality, the default schema URI (it means "let the validator decide" basically)
