### PR TITLE
perf: return 1-length results if merging schemas

### DIFF
--- a/polars-genson-py/src/expressions.rs
+++ b/polars-genson-py/src/expressions.rs
@@ -93,6 +93,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
 
     if kwargs.merge_schemas {
         // Original behavior: merge all schemas into one
+        // We only need a single row, and we are allowed to change the length
         // Wrap EVERYTHING in panic catching, including config creation
         let result = panic::catch_unwind(|| -> Result<String, String> {
             let config = SchemaInferenceConfig {
@@ -113,10 +114,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
                 if kwargs.debug {
                     eprintln!("DEBUG: Successfully generated merged schema");
                 }
-                Ok(Series::new(
-                    "schema".into(),
-                    vec![schema_json; series.len()],
-                ))
+                Ok(Series::new("schema".into(), vec![schema_json; 1]))
             }
             Ok(Err(e)) => Err(PolarsError::ComputeError(
                 format!("Merged schema processing failed: {}", e).into(),


### PR DESCRIPTION
- The `changes_length` parameter should allow `merge_schemas=True` to make a 1-length Series now aefb45d
- Reduced the length to 1 explicitly as `vec![..., 1]` now 6bec6a3