### PR TITLE
fix: deploy from dir

### DIFF
--- a/docs/vercel/build.sh
+++ b/docs/vercel/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -ex
+PYPROJ_SUBDIR="./polars-genson-py/"
 
 # 1) Reactivate the same uv-managed venv.
 #    (On Vercel, your workspace is ephemeral between these steps,
 #     but re-sourcing ensures we’re in the same environment as deployed.)
-source .venv/bin/activate
+source $PYPROJ_SUBDIR/.venv/bin/activate
 
 # 2) Double check that we have the correct interpreter.
 python --version

--- a/docs/vercel/deploy.sh
+++ b/docs/vercel/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+PYPROJ_SUBDIR="./polars-genson-py/"
 
 # 1) Ensure wget is available (Vercel's Amazon Linux images may not include it by default).
 yum install -y wget
@@ -13,21 +14,22 @@ find ./ -iname uv -type f 2> /dev/null
 export PATH="$HOME/.local/bin:$PATH"
 
 # 4) Create a Python 3.11 venv using uv’s built-in venv command.
-uv venv --python 3.11
+uv venv --directory $PYPROJ_SUBDIR --python 3.11
 
 # 5) Activate the venv. (Alternatively, you could use $(uv python find) but activating is simpler.)
-source .venv/bin/activate
+source $PYPROJ_SUBDIR/.venv/bin/activate
 
 # 6) Check the Python version, just to confirm everything is correct.
-python --version
+$(uv python find --directory $PYPROJ_SUBDIR) --version
 
 # 7) Install dependencies:
 #    - First pin urllib3<2 (to avoid known breakage).
 #    - Then install your docs extra so that mkdocs & related are available.
 uv pip install "urllib3<2"
-uv pip install .[docs]
+# uv pip install  .[docs]
+uv sync --directory $PYPROJ_SUBDIR --no-install-project --only-group doc
 
 # 8) Optionally run mkdocs here if you need it immediately in “deploy”
 #    (e.g., if your older script used ‘pdm run mkdocs’ at this point).
 #    Otherwise, you can defer building to build.sh. For parity with your old deploy script:
-uv run mkdocs --help && echo $?
+$(uv python find --directory $PYPROJ_SUBDIR) -m mkdocs --help && echo $?

--- a/polars-genson-py/pyproject.toml
+++ b/polars-genson-py/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=1.0,<2.0", "patchelf>=0.14", "polars>=0.20.6"]
+requires = ["maturin>=1.0,<2.0", "patchelf>=0.14"]
 
 [project]
 authors = [{ email = "louismmx@gmail.com", name = "Louis Maddox" }]

--- a/polars-genson-py/python/polars_genson/__init__.py
+++ b/polars-genson-py/python/polars_genson/__init__.py
@@ -57,9 +57,9 @@ def schema_to_json(schema: pl.Schema) -> str:
     str
         JSON string representation of the schema
     """
-    assert isinstance(schema, pl.Schema), (
-        f"Expected Schema, got {type(schema)}: {schema}"
-    )
+    assert isinstance(
+        schema, pl.Schema
+    ), f"Expected Schema, got {type(schema)}: {schema}"
     empty_df = schema.to_frame()
     return _rust_schema_to_json(empty_df)
 

--- a/polars-genson-py/tests/dtypes_test.py
+++ b/polars-genson-py/tests/dtypes_test.py
@@ -34,9 +34,9 @@ class TestDtypeParsing:
 
         for dtype_str, expected in test_cases:
             result = _parse_polars_dtype(dtype_str)
-            assert result == expected, (
-                f"Failed for {dtype_str}: got {result}, expected {expected}"
-            )
+            assert (
+                result == expected
+            ), f"Failed for {dtype_str}: got {result}, expected {expected}"
 
     def test_decimal_parsing(self):
         """Test Decimal type parsing with various formats."""

--- a/polars-genson-py/tests/nested_complex_test.py
+++ b/polars-genson-py/tests/nested_complex_test.py
@@ -361,8 +361,8 @@ def test_comprehensive_nested_arrays_lists_integration():
 
     for dtype_str, expected in test_cases:
         result = _parse_polars_dtype(dtype_str)
-        assert result == expected, (
-            f"Failed for {dtype_str}: got {result}, expected {expected}"
-        )
+        assert (
+            result == expected
+        ), f"Failed for {dtype_str}: got {result}, expected {expected}"
 
     print("✅ All nested Arrays/Lists test cases passed!")


### PR DESCRIPTION
Get the uv setup in mkdocs up to scratch

- deploy from subdir (parameterise this with bash variable for portability in future)
- use 'uv sync' not 'uv pip install', clear use of uv group, do not install the project itself (important as it would bring in Polars!)
- use `$(uv python find --directory $PYPROJECT_DIR` instead of `uv run` which would potentially clash and trigger installation if module not in venv)
- remove polars from build deps