### PR TITLE
test: polars extension normalise tests

### DIFF
--- a/genson-cli/tests/normalise.rs
+++ b/genson-cli/tests/normalise.rs
@@ -67,3 +67,152 @@ fn test_normalise_union_coercion_snapshot() {
     // Compare against snapshot
     assert_snapshot!("normalise_union_coercion", stdout_str);
 }
+
+#[test]
+fn test_normalise_string_or_array_snapshot() {
+    // NDJSON with heterogeneous shapes for "foo"
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"foo": "json"}}"#).unwrap();
+    writeln!(temp, r#"{{"foo": ["bar", "baz"]}}"#).unwrap();
+
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot ensures scalar string widened to array, and arrays pass through
+    assert_snapshot!("normalise_string_or_array", stdout_str);
+}
+
+#[test]
+fn test_normalise_string_or_array_snapshot_rev() {
+    // NDJSON with heterogeneous shapes for "foo"
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"foo": ["bar", "baz"]}}"#).unwrap();
+    writeln!(temp, r#"{{"foo": "json"}}"#).unwrap();
+
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot ensures scalar string widened to array, and arrays pass through
+    assert_snapshot!("normalise_string_or_array_rev", stdout_str);
+}
+
+#[test]
+fn test_normalise_object_or_array_snapshot() {
+    // Create NDJSON file with mixed object/array values for the same field
+    let mut temp = NamedTempFile::new().unwrap();
+    // First row: array of objects
+    writeln!(temp, r#"{{"foo": [{{"bar": 1}}]}}"#).unwrap();
+    // Second row: single object
+    writeln!(temp, r#"{{"foo": {{"bar": 2}}}}"#).unwrap();
+
+    // Run CLI with normalisation enabled
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show that the single object was widened to an array
+    assert_snapshot!("normalise_object_or_array", stdout_str);
+}
+
+#[test]
+fn test_normalise_missing_field_snapshot() {
+    // NDJSON with one row missing the "foo" field entirely
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"foo": "present"}}"#).unwrap();
+    writeln!(temp, r#"{{"bar": 123}}"#).unwrap(); // foo missing here
+
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show that the second row has "foo": null
+    assert_snapshot!("normalise_missing_field", stdout_str);
+}
+
+#[test]
+fn test_normalise_null_vs_missing_field_snapshot() {
+    // First row: foo explicitly null
+    // Second row: foo completely missing
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"foo": null, "bar": 1}}"#).unwrap();
+    writeln!(temp, r#"{{"bar": 2}}"#).unwrap();
+
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show: row 1 foo=null, row 2 foo=null (injected for missing)
+    assert_snapshot!("normalise_null_vs_missing_field", stdout_str);
+}
+
+#[test]
+fn test_normalise_empty_map_snapshot() {
+    // NDJSON where "labels" is always an empty map
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"id": "A", "labels": {{}}}}"#).unwrap();
+    writeln!(temp, r#"{{"id": "B", "labels": {{}}}}"#).unwrap();
+
+    // Run CLI with normalisation enabled (default empty_as_null=true)
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show labels normalised to null
+    assert_snapshot!("normalise_empty_map", stdout_str);
+}
+
+#[test]
+fn test_normalise_map_threshold_snapshot() {
+    // NDJSON where "labels" vary but all values are strings
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"id": "A", "labels": {{"en": "Hello"}}}}"#).unwrap();
+    writeln!(temp, r#"{{"id": "B", "labels": {{"fr": "Bonjour"}}}}"#).unwrap();
+
+    // Use low map threshold to force rewriting into "map" type
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args([
+        "--normalise",
+        "--ndjson",
+        "--map-threshold",
+        "1",
+        temp.path().to_str().unwrap(),
+    ]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show "labels" stabilised as a map (additionalProperties form)
+    assert_snapshot!("normalise_map_threshold", stdout_str);
+}
+
+#[test]
+fn test_normalise_scalar_to_map_snapshot() {
+    // NDJSON where "labels" is sometimes scalar
+    let mut temp = NamedTempFile::new().unwrap();
+    writeln!(temp, r#"{{"id": "A", "labels": "foo"}}"#).unwrap();
+    writeln!(temp, r#"{{"id": "B", "labels": {{"en": "Hello"}}}}"#).unwrap();
+
+    // Run CLI with normalisation enabled
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    cmd.args(["--normalise", "--ndjson", temp.path().to_str().unwrap()]);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    // Snapshot should show row 1 coerced into {"labels":{"default":"foo"}}
+    assert_snapshot!("normalise_scalar_to_map", stdout_str);
+}

--- a/genson-cli/tests/snapshots/normalise__normalise_empty_map.snap.new
+++ b/genson-cli/tests/snapshots/normalise__normalise_empty_map.snap.new
@@ -1,0 +1,7 @@
+---
+source: genson-cli/tests/normalise.rs
+assertion_line: 175
+expression: stdout_str
+---
+{"id":"A","labels":{}}
+{"id":"B","labels":{}}

--- a/genson-cli/tests/snapshots/normalise__normalise_map_threshold.snap.new
+++ b/genson-cli/tests/snapshots/normalise__normalise_map_threshold.snap.new
@@ -1,0 +1,7 @@
+---
+source: genson-cli/tests/normalise.rs
+assertion_line: 199
+expression: stdout_str
+---
+{"id":"A","labels":{"en":"Hello"}}
+{"id":"B","labels":{"fr":"Bonjour"}}

--- a/genson-cli/tests/snapshots/normalise__normalise_missing_field.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_missing_field.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"foo":"present","bar":null}
+{"foo":null,"bar":123}

--- a/genson-cli/tests/snapshots/normalise__normalise_null_vs_missing_field.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_null_vs_missing_field.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"foo":null,"bar":1}
+{"foo":null,"bar":2}

--- a/genson-cli/tests/snapshots/normalise__normalise_object_or_array.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_object_or_array.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"foo":[{"bar":1}]}
+{"foo":[{"bar":2}]}

--- a/genson-cli/tests/snapshots/normalise__normalise_scalar_to_map.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_scalar_to_map.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"id":"A","labels":{"en":null}}
+{"id":"B","labels":{"en":"Hello"}}

--- a/genson-cli/tests/snapshots/normalise__normalise_string_or_array.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_string_or_array.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"foo":["json"]}
+{"foo":["bar","baz"]}

--- a/genson-cli/tests/snapshots/normalise__normalise_string_or_array_rev.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_string_or_array_rev.snap
@@ -1,0 +1,6 @@
+---
+source: genson-cli/tests/normalise.rs
+expression: stdout_str
+---
+{"foo":["bar","baz"]}
+{"foo":["json"]}

--- a/polars-genson-py/tests/normalise_test.py
+++ b/polars-genson-py/tests/normalise_test.py
@@ -58,3 +58,133 @@ def test_string_coercion_enabled():
     # String "42" is coerced to int, "true" coerced to bool
     assert '"id":42' in out[0]
     assert '"active":true' in out[0]
+
+
+def run_norm(rows, *, empty_as_null=True, coerce_strings=False, map_threshold=None):
+    """Helper: run normalisation on a list of JSON strings."""
+    df = pl.DataFrame({"json_data": rows})
+    kwargs = {"empty_as_null": empty_as_null, "coerce_strings": coerce_strings}
+    if map_threshold is not None:
+        kwargs["map_threshold"] = map_threshold
+    return df.genson.normalise_json("json_data", **kwargs).to_list()
+
+
+def test_normalise_ndjson_like():
+    """Mixed rows: empty arrays/maps become null; strings preserved."""
+    rows = [
+        '{"id":"Q1","aliases":[],"labels":{},"description":"Example entity"}',
+        '{"id":"Q2","aliases":["Sample"],"labels":{"en":"Hello"},"description":null}',
+        '{"id":"Q3","aliases":null,"labels":{"fr":"Bonjour"},"description":"Third one"}',
+        '{"id":"Q4","aliases":["X","Y"],"labels":{},"description":""}',
+    ]
+    out = run_norm(rows, map_threshold=1)
+    # Snapshot-like check: aliases=[] → null, labels={} → null (with default empty_as_null=True)
+    assert '"aliases":null' in out[0]
+    assert '"labels":null' in out[0]
+
+
+def test_normalise_union_coercion():
+    """Unions: string inputs coerced to int/float/bool when allowed."""
+    rows = [
+        '{"int_field":1,"float_field":3.14,"bool_field":true}',
+        '{"int_field":"42","float_field":"2.718","bool_field":"false"}',
+        '{"int_field":null,"float_field":null}',
+    ]
+    out = run_norm(rows, coerce_strings=True)
+    # String values coerced into proper types
+    assert '"int_field":42' in out[1]
+    assert '"float_field":2.718' in out[1]
+    assert '"bool_field":false' in out[1]
+
+
+def test_normalise_string_or_array():
+    """Scalars widened to singleton arrays when unioned with arrays."""
+    rows = [
+        '{"foo":"json"}',
+        '{"foo":["bar","baz"]}',
+    ]
+    out = run_norm(rows)
+    # Scalars widened to singleton arrays
+    assert out[0].startswith('{"foo":["json"]}')
+    assert out[1] == '{"foo":["bar","baz"]}'
+
+
+def test_normalise_string_or_array_rev():
+    """Order of rows does not affect string→array widening behaviour."""
+    rows = [
+        '{"foo":["bar","baz"]}',
+        '{"foo":"json"}',
+    ]
+    out = run_norm(rows)
+    # Same outcome regardless of row order
+    assert out[0] == '{"foo":["bar","baz"]}'
+    assert out[1].startswith('{"foo":["json"]}')
+
+
+def test_normalise_object_or_array():
+    """Single objects are widened to arrays."""
+    rows = [
+        '{"foo":[{"bar":1}]}',
+        '{"foo":{"bar":2}}',
+    ]
+    out = run_norm(rows)
+    # Single object widened to array-of-objects
+    assert out[1] == '{"foo":[{"bar":2}]}'
+
+
+def test_normalise_missing_field():
+    """Missing fields are injected as null to stabilise schema."""
+    rows = [
+        '{"foo":"present"}',
+        '{"bar":123}',  # foo missing
+    ]
+    out = run_norm(rows)
+    # Missing foo should be injected as null
+    assert '"foo":"present"' in out[0]
+    assert '"foo":null' in out[1]
+
+
+def test_normalise_null_vs_missing_field():
+    """Explicit null and missing values are both normalised to null."""
+    rows = [
+        '{"foo":null,"bar":1}',
+        '{"bar":2}',  # foo missing
+    ]
+    out = run_norm(rows)
+    # Both rows should agree: foo=null
+    assert '"foo":null' in out[0]
+    assert '"foo":null' in out[1]
+
+
+def test_normalise_empty_map_default_null():
+    """Empty maps are normalised to null when empty_as_null=True."""
+    rows = [
+        '{"id":"A","labels":{"en":"Hello"}}',
+        '{"id":"B","labels":{}}',
+    ]
+    out = run_norm(rows, map_threshold=1)
+    # Empty maps normalised to null by default
+    assert '"labels":null' in out[1]
+
+
+def test_normalise_map_threshold_forces_map():
+    """Low map_threshold forces heterogeneous objects into map type."""
+    rows = [
+        '{"id":"A","labels":{"en":"Hello"}}',
+        '{"id":"B","labels":{"fr":"Bonjour"}}',
+    ]
+    out = run_norm(rows, map_threshold=1)
+    # Labels stabilised as a map
+    assert '"labels":{"en":"Hello"}' in out[0] or '"labels":{"fr":"Bonjour"}' in out[1]
+
+
+def test_normalise_scalar_to_map():
+    """Scalar values are widened into maps with a 'default' key."""
+    rows = [
+        '{"id":"A","labels":"foo"}',
+        '{"id":"B","labels":{"en":"Hello"}}',
+    ]
+    out = run_norm(rows, map_threshold=0)
+    # Scalar widened into {"default": ...}
+    assert '"labels":{"default":"foo"}' in out[0]
+    assert '"labels":{"en":"Hello"}}' in out[1]


### PR DESCRIPTION
It looks like there is some misbehaviour in the CLI RE: empty as null, but the Polars extension behaves correctly, pinned the behaviour with tests