### PR TITLE
refactor: simplify claims fixture

### DIFF
--- a/genson-cli/tests/data/further_simplified_claims_fixture.json
+++ b/genson-cli/tests/data/further_simplified_claims_fixture.json
@@ -1,0 +1,48 @@
+{
+  "claims": {
+    "P31": [
+      {
+        "mainsnak": {
+          "property": "P31",
+          "datatype": "wikibase-item",
+          "datavalue": {
+            "value": {
+              "id": "Q5",
+              "labels": {
+                "en": "human",
+                "fr": "être humain"
+              }
+            },
+            "type": "wikibase-entityid"
+          },
+          "property-labels": {
+            "en": "instance of",
+            "fr": "est une instance de"
+          }
+        },
+        "rank": "normal"
+      }
+    ],
+    "P569": [
+      {
+        "mainsnak": {
+          "property": "P569",
+          "datatype": "time",
+          "datavalue": {
+            "value": {
+              "time": "+1956-05-08T00:00:00Z",
+              "precision": 11,
+              "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+            },
+            "type": "time"
+          },
+          "property-labels": {
+            "en": "date of birth",
+            "fr": "date de naissance"
+          }
+        },
+        "rank": "normal"
+      }
+    ]
+  }
+}

--- a/genson-cli/tests/data/simplified_claims_fixture.json
+++ b/genson-cli/tests/data/simplified_claims_fixture.json
@@ -1,0 +1,65 @@
+{
+  "claims": {
+    "P31": [
+      {
+        "mainsnak": {
+          "property": "P31",
+          "datatype": "wikibase-item",
+          "datavalue": {
+            "value": {
+              "id": "Q5",
+              "labels": {
+                "en": "human",
+                "fr": "être humain"
+              }
+            },
+            "type": "wikibase-entityid"
+          },
+          "property-labels": {
+            "en": "instance of",
+            "fr": "est une instance de"
+          }
+        },
+        "rank": "normal"
+      }
+    ],
+    "P569": [
+      {
+        "mainsnak": {
+          "property": "P569",
+          "datatype": "time",
+          "datavalue": {
+            "value": {
+              "time": "+1956-05-08T00:00:00Z",
+              "precision": 11,
+              "calendarmodel": "http://www.wikidata.org/entity/Q1985727"
+            },
+            "type": "time"
+          },
+          "property-labels": {
+            "en": "date of birth",
+            "fr": "date de naissance"
+          }
+        },
+        "rank": "normal"
+      }
+    ],
+    "P1476": [
+      {
+        "mainsnak": {
+          "property": "P1476",
+          "datatype": "monolingualtext",
+          "datavalue": {
+            "value": { "text": "Example title", "language": "en" },
+            "type": "monolingualtext"
+          },
+          "property-labels": {
+            "en": "title",
+            "fr": "titre"
+          }
+        },
+        "rank": "normal"
+      }
+    ]
+  }
+}

--- a/genson-cli/tests/data/super_simplified_claims_fixture.json
+++ b/genson-cli/tests/data/super_simplified_claims_fixture.json
@@ -1,0 +1,17 @@
+{
+  "claims": {
+    "P31": [
+      {
+        "mainsnak": {
+          "property": "P31"
+        },
+        "rank": "normal"
+      }
+    ],
+    "P569": [
+      {
+        "rank": "normal"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add simplified fixtures that identify the real problem with the claims fixture:
the failure to unify

$$
\text{map}\left< \bigcup_{i=1}^n \text{array}(R_i) \right>
\longrightarrow
\text{map}\left< \text{array}(R_{\text{unified}}) \right>
$$

In other words we have covered the case when the map is over individual records:

$$
\text{map}\left< \bigcup_{i=1}^n R_i \right>
\longrightarrow
\text{map}\left< R_{\text{unified}} \right>
$$

but when we have a map over arrays of records it becomes a different problem

$$
\text{map}\left< \bigcup_{i=1}^n \text{array}(R_i) \right>
\longrightarrow
\text{map}\left< \text{array}(R_{\text{unified}}) \right>
$$

## Minimal fixture

This PR introduces a simple example of 

- a claims field
  - containing 2 map string keys "P31" and "P569"
    - both of which are arrays of records
    - one of which is an array of record{mainsnak,rank}, the other is an array of record{rank}

https://github.com/lmmx/polars-genson/blob/67026c26b42e57119b0efec86d20fc1b1fffe60e/genson-cli/tests/data/super_simplified_claims_fixture.json#L1-L17

This is the minimal repro for a map of <array of (record) of multiple kinds>