### PR TITLE
harmonise synthetic key for object-promoted scalars in map unification and normalisation

### DIFF
--- a/genson-cli/tests/snapshots/normalise__normalise_scalar_to_map.snap
+++ b/genson-cli/tests/snapshots/normalise__normalise_scalar_to_map.snap
@@ -2,7 +2,7 @@
 source: genson-cli/tests/normalise.rs
 expression: value
 info:
-  approved: true
+  approved: false
   args:
     - "--normalise"
     - "--ndjson"
@@ -15,5 +15,5 @@ info:
       labels:
         en: Hello
 ---
-{"id":"A","labels":{"default":"foo"}}
+{"id":"A","labels":{"labels__string":"foo"}}
 {"id":"B","labels":{"en":"Hello"}}

--- a/genson-core/src/normalise.rs
+++ b/genson-core/src/normalise.rs
@@ -277,7 +277,7 @@ pub fn normalise_value(
                     let mut synthetic = serde_json::Map::new();
                     let scalar_type = get_scalar_type_from_value(&v);
                     let wrapped_key =
-                        make_promoted_scalar_key(field_name.unwrap_or(""), &scalar_type);
+                        make_promoted_scalar_key(field_name.unwrap_or(""), scalar_type);
                     synthetic.insert(
                         wrapped_key,
                         normalise_value(v, values_schema, cfg, field_name),

--- a/genson-core/src/normalise.rs
+++ b/genson-core/src/normalise.rs
@@ -1,3 +1,4 @@
+use crate::schema::core::make_promoted_scalar_key;
 use serde_json::{json, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -51,6 +52,16 @@ fn apply_map_encoding(m: serde_json::Map<String, Value>, encoding: MapEncoding) 
                 .collect();
             Value::Array(arr)
         }
+    }
+}
+
+fn get_scalar_type_from_value(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "string",
+        Value::Number(n) if n.is_i64() => "int",
+        Value::Number(_) => "float",
+        Value::Bool(_) => "boolean",
+        _ => "unknown",
     }
 }
 
@@ -126,7 +137,12 @@ fn apply_map_encoding(m: serde_json::Map<String, Value>, encoding: MapEncoding) 
 ///   it does not match the schema.
 /// * Avro’s full union semantics are simplified here: only the first matching
 ///   branch is tried, not all possible branches.
-pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> Value {
+pub fn normalise_value(
+    value: Value,
+    schema: &Value,
+    cfg: &NormaliseConfig,
+    field_name: Option<&str>,
+) -> Value {
     match schema {
         // Primitive types
         Value::String(t) if t == "string" => match value {
@@ -199,7 +215,10 @@ pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> V
                                 }
                             }
                         };
-                        out.insert(name.clone(), normalise_value(val, field_schema, cfg));
+                        out.insert(
+                            name.clone(),
+                            normalise_value(val, field_schema, cfg, Some(name)),
+                        );
                     }
                 }
             }
@@ -215,10 +234,10 @@ pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> V
                 Value::Array(arr) if arr.is_empty() && cfg.empty_as_null => Value::Null,
                 Value::Array(arr) => Value::Array(
                     arr.into_iter()
-                        .map(|v| normalise_value(v, items_schema, cfg))
+                        .map(|v| normalise_value(v, items_schema, cfg, field_name))
                         .collect(),
                 ),
-                v => Value::Array(vec![normalise_value(v, items_schema, cfg)]),
+                v => Value::Array(vec![normalise_value(v, items_schema, cfg, field_name)]),
             }
         }
 
@@ -238,13 +257,15 @@ pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> V
                     if values_schema.get("type") == Some(&Value::String("object".into())) {
                         // --- Map of records ---
                         for (k, v) in m {
-                            let normalised_record = normalise_value(v, values_schema, cfg);
+                            let normalised_record =
+                                normalise_value(v, values_schema, cfg, Some(&k));
                             out.insert(k, normalised_record);
                         }
                     } else {
                         // --- Map of scalars (existing behaviour) ---
                         for (k, v) in m {
-                            out.insert(k, normalise_value(v, values_schema, cfg));
+                            let normalised_value = normalise_value(v, values_schema, cfg, Some(&k));
+                            out.insert(k, normalised_value);
                         }
                     }
 
@@ -254,7 +275,13 @@ pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> V
                 v => {
                     // Scalar fallback: wrap as {"default": v}
                     let mut synthetic = serde_json::Map::new();
-                    synthetic.insert("default".into(), normalise_value(v, values_schema, cfg));
+                    let scalar_type = get_scalar_type_from_value(&v);
+                    let wrapped_key =
+                        make_promoted_scalar_key(field_name.unwrap_or(""), &scalar_type);
+                    synthetic.insert(
+                        wrapped_key,
+                        normalise_value(v, values_schema, cfg, field_name),
+                    );
                     apply_map_encoding(synthetic, cfg.map_encoding)
                 }
             }
@@ -269,11 +296,11 @@ pub fn normalise_value(value: Value, schema: &Value, cfg: &NormaliseConfig) -> V
                 } else {
                     // normalise against the first non-null branch
                     let branch = types.iter().find(|t| *t != "null").unwrap();
-                    normalise_value(value, branch, cfg)
+                    normalise_value(value, branch, cfg, field_name)
                 }
             } else {
                 // pick first type
-                normalise_value(value, &types[0], cfg)
+                normalise_value(value, &types[0], cfg, field_name)
             }
         }
 
@@ -293,7 +320,7 @@ pub fn normalise_values(values: Vec<Value>, schema: &Value, cfg: &NormaliseConfi
                     std::iter::once((field.clone(), v)).collect::<serde_json::Map<String, Value>>(),
                 );
             }
-            normalise_value(v, schema, cfg)
+            normalise_value(v, schema, cfg, None) // Only the root call passes field name as None
         })
         .collect()
 }

--- a/genson-core/src/schema.rs
+++ b/genson-core/src/schema.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::panic::{self, AssertUnwindSafe};
 
-mod core;
+pub(crate) mod core;
 pub use core::*;
 mod map_inference;
 use map_inference::*;

--- a/genson-core/src/schema/core.rs
+++ b/genson-core/src/schema/core.rs
@@ -149,3 +149,12 @@ impl SchemaInferenceResult {
         )
     }
 }
+
+/// Generate a consistent key name for promoted scalar values.
+///
+/// Creates keys in the format `{field_prefix}__{scalar_type}` for scalar values
+/// that are promoted to object fields during schema unification or normalisation.
+pub fn make_promoted_scalar_key(field_prefix: &str, scalar_type: &str) -> String {
+    // Could be parameterised by config in future to make configurable
+    format!("{}__{}", field_prefix, scalar_type)
+}

--- a/genson-core/src/schema/map_inference/unification.rs
+++ b/genson-core/src/schema/map_inference/unification.rs
@@ -1,5 +1,8 @@
 // genson-core/src/schema/unification.rs
-use crate::{debug, debug_verbose, schema::core::SchemaInferenceConfig};
+use crate::{
+    debug, debug_verbose,
+    schema::core::{make_promoted_scalar_key, SchemaInferenceConfig},
+};
 use serde_json::{json, Map, Value};
 
 /// Normalize a schema that may be wrapped in one or more layers of
@@ -185,7 +188,7 @@ fn try_scalar_promotion(
         return None;
     };
 
-    let wrapped_key = format!("{}__{}", field_name, scalar_type);
+    let wrapped_key = make_promoted_scalar_key(field_name, &scalar_type);
 
     debug!(
         config,

--- a/genson-core/src/tests/normalise.rs
+++ b/genson-core/src/tests/normalise.rs
@@ -14,7 +14,7 @@ fn test_normalise_record() {
 
     let cfg = NormaliseConfig::default();
     let input = json!({"id": 42}); // id is number, labels missing
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(normalised, json!({"id": "42", "labels": Value::Null}));
 }
@@ -25,7 +25,7 @@ fn test_normalise_array_union() {
     let cfg = NormaliseConfig::default();
 
     let input = json!("hello"); // scalar string
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(normalised, json!(["hello"]));
 }
@@ -36,7 +36,7 @@ fn test_empty_map_to_null() {
     let cfg = NormaliseConfig::default();
 
     let input = json!({});
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(normalised, Value::Null);
 }
@@ -50,7 +50,7 @@ fn test_empty_map_preserved_if_flag_off() {
     };
 
     let input = json!({});
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(normalised, json!({}));
 }
@@ -77,7 +77,7 @@ fn test_string_coercion_toggle() {
         coerce_string: false,
         ..NormaliseConfig::default()
     };
-    let norm_no_coerce = normalise_value(input.clone(), &schema, &cfg_no_coerce);
+    let norm_no_coerce = normalise_value(input.clone(), &schema, &cfg_no_coerce, None);
     assert_eq!(
         norm_no_coerce,
         json!({
@@ -92,7 +92,7 @@ fn test_string_coercion_toggle() {
         coerce_string: true,
         ..NormaliseConfig::default()
     };
-    let norm_coerce = normalise_value(input, &schema, &cfg_coerce);
+    let norm_coerce = normalise_value(input, &schema, &cfg_coerce, None);
     assert_eq!(
         norm_coerce,
         json!({
@@ -125,7 +125,7 @@ fn test_normalise_map_of_records() {
 
     let cfg = NormaliseConfig::default();
 
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     // Expect same shape back (since it's already valid against schema)
     let expected = json!({
@@ -159,7 +159,7 @@ fn test_normalise_map_of_records_with_null() {
 
     let cfg = NormaliseConfig::default();
 
-    let normalised = normalise_value(input, &schema, &cfg);
+    let normalised = normalise_value(input, &schema, &cfg, None);
 
     let expected = json!({
         "en": { "language": "en", "value": "Hello" },

--- a/genson-core/tests/map_encoding.rs
+++ b/genson-core/tests/map_encoding.rs
@@ -12,7 +12,7 @@ fn test_map_encoding_mapping() {
     };
 
     let input = json!({"en": "Hello", "fr": "Bonjour"});
-    let norm = normalise_value(input, &schema, &cfg);
+    let norm = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(norm, json!({"en": "Hello", "fr": "Bonjour"}));
 }
@@ -27,7 +27,7 @@ fn test_map_encoding_entries() {
     };
 
     let input = json!({"en": "Hello", "fr": "Bonjour"});
-    let norm = normalise_value(input, &schema, &cfg);
+    let norm = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(
         norm,
@@ -48,7 +48,7 @@ fn test_map_encoding_key_value_entries() {
     };
 
     let input = json!({"en": "Hello", "fr": "Bonjour"});
-    let norm = normalise_value(input, &schema, &cfg);
+    let norm = normalise_value(input, &schema, &cfg, None);
 
     assert_eq!(
         norm,
@@ -70,7 +70,7 @@ fn test_map_encoding_scalar_fallback() {
         ..NormaliseConfig::default()
     };
     assert_eq!(
-        normalise_value(json!("foo"), &schema, &cfg),
+        normalise_value(json!("foo"), &schema, &cfg, None),
         json!({"default": "foo"})
     );
 
@@ -80,7 +80,7 @@ fn test_map_encoding_scalar_fallback() {
         ..NormaliseConfig::default()
     };
     assert_eq!(
-        normalise_value(json!("foo"), &schema, &cfg),
+        normalise_value(json!("foo"), &schema, &cfg, None),
         json!([{"default": "foo"}])
     );
 
@@ -90,7 +90,7 @@ fn test_map_encoding_scalar_fallback() {
         ..NormaliseConfig::default()
     };
     assert_eq!(
-        normalise_value(json!("foo"), &schema, &cfg),
+        normalise_value(json!("foo"), &schema, &cfg, None),
         json!([{"key": "default", "value": "foo"}])
     );
 }

--- a/genson-core/tests/normalise.rs
+++ b/genson-core/tests/normalise.rs
@@ -13,17 +13,20 @@ fn test_array_empty_behavior() {
         empty_as_null: true,
         ..NormaliseConfig::default()
     };
-    assert_eq!(normalise_value(json!([]), &schema, &cfg), json!(null));
+    assert_eq!(normalise_value(json!([]), &schema, &cfg, None), json!(null));
 
     // empty_as_null = false
     let cfg = NormaliseConfig {
         empty_as_null: false,
         ..NormaliseConfig::default()
     };
-    assert_eq!(normalise_value(json!([]), &schema, &cfg), json!([]));
+    assert_eq!(normalise_value(json!([]), &schema, &cfg, None), json!([]));
 
     // scalar coerced into array
-    assert_eq!(normalise_value(json!("foo"), &schema, &cfg), json!(["foo"]));
+    assert_eq!(
+        normalise_value(json!("foo"), &schema, &cfg, None),
+        json!(["foo"])
+    );
 }
 
 /// Maps: empty → null (with flag), empty → {} (without flag).
@@ -35,16 +38,16 @@ fn test_map_empty_behavior() {
         empty_as_null: true,
         ..NormaliseConfig::default()
     };
-    assert_eq!(normalise_value(json!({}), &schema, &cfg), json!(null));
+    assert_eq!(normalise_value(json!({}), &schema, &cfg, None), json!(null));
 
     let cfg = NormaliseConfig {
         empty_as_null: false,
         ..NormaliseConfig::default()
     };
-    assert_eq!(normalise_value(json!({}), &schema, &cfg), json!({}));
+    assert_eq!(normalise_value(json!({}), &schema, &cfg, None), json!({}));
 
     // Fallback scalar coerced into map
-    let val = normalise_value(json!("foo"), &schema, &cfg);
+    let val = normalise_value(json!("foo"), &schema, &cfg, None);
     assert_eq!(val, json!({"default":"foo"}));
 }
 
@@ -65,7 +68,7 @@ fn test_nested_record_array_field() {
         ..NormaliseConfig::default()
     };
     let input = json!({"id":"1","tags":[]});
-    let norm = normalise_value(input, &schema, &cfg);
+    let norm = normalise_value(input, &schema, &cfg, None);
     assert_eq!(norm, json!({"id":"1","tags":null}));
 
     let cfg = NormaliseConfig {
@@ -73,7 +76,7 @@ fn test_nested_record_array_field() {
         ..NormaliseConfig::default()
     };
     let input = json!({"id":"1","tags":[]});
-    let norm = normalise_value(input, &schema, &cfg);
+    let norm = normalise_value(input, &schema, &cfg, None);
     assert_eq!(norm, json!({"id":"1","tags":[]}));
 }
 
@@ -87,10 +90,13 @@ fn test_union_precedence_array() {
     };
 
     // null stays null
-    assert_eq!(normalise_value(json!(null), &schema, &cfg), json!(null));
+    assert_eq!(
+        normalise_value(json!(null), &schema, &cfg, None),
+        json!(null)
+    );
 
     // scalar coerced to array
-    let val = normalise_value(json!("x"), &schema, &cfg);
+    let val = normalise_value(json!("x"), &schema, &cfg, None);
     assert_eq!(val, json!(["x"]));
 }
 
@@ -104,7 +110,7 @@ fn test_union_precedence_map() {
     };
 
     // scalar coerced into map, because map branch is first non-null
-    let val = normalise_value(json!("foo"), &schema, &cfg);
+    let val = normalise_value(json!("foo"), &schema, &cfg, None);
     assert_eq!(val, json!({"default":"foo"}));
 }
 
@@ -140,7 +146,7 @@ fn test_map_scalar_fallback_encodings() {
         map_encoding: MapEncoding::Mapping,
         ..NormaliseConfig::default()
     };
-    let val = normalise_value(json!("foo"), &schema, &cfg);
+    let val = normalise_value(json!("foo"), &schema, &cfg, None);
     assert_eq!(val, json!({"default": "foo"}));
 
     // Entries
@@ -148,7 +154,7 @@ fn test_map_scalar_fallback_encodings() {
         map_encoding: MapEncoding::Entries,
         ..NormaliseConfig::default()
     };
-    let val = normalise_value(json!("foo"), &schema, &cfg);
+    let val = normalise_value(json!("foo"), &schema, &cfg, None);
     assert_eq!(val, json!([{"default": "foo"}]));
 
     // KeyValueEntries
@@ -156,6 +162,6 @@ fn test_map_scalar_fallback_encodings() {
         map_encoding: MapEncoding::KeyValueEntries,
         ..NormaliseConfig::default()
     };
-    let val = normalise_value(json!("foo"), &schema, &cfg);
+    let val = normalise_value(json!("foo"), &schema, &cfg, None);
     assert_eq!(val, json!([{"key": "default", "value": "foo"}]));
 }

--- a/polars-genson-py/tests/normalise_test.py
+++ b/polars-genson-py/tests/normalise_test.py
@@ -214,7 +214,7 @@ def test_normalise_scalar_to_map_kv():
     out = run_norm(rows, map_threshold=0)
     # Scalar widened into {"default": ...}
     assert out == [
-        '{"id":"A","labels":[{"key":"default","value":"foo"}]}',
+        '{"id":"A","labels":[{"key":"labels__string","value":"foo"}]}',
         '{"id":"B","labels":[{"key":"en","value":"Hello"}]}',
     ]
 
@@ -227,7 +227,7 @@ def test_normalise_scalar_to_map_mapping():
     ]
     out = run_norm(rows, map_threshold=0, map_encoding="mapping")
     # Scalar widened into {"default": ...}
-    assert '"labels":{"default":"foo"}' in out[0]
+    assert '"labels":{"labels__string":"foo"}' in out[0]
     assert '"labels":{"en":"Hello"}}' in out[1]
 
 


### PR DESCRIPTION
- **refactor: use the same schema inference and normalisation synthetic keys for both record and scalar maps**
- **test(normalise_value): amend test signatures with new param**

Removes the old behaviour where scalars would get promoted to a key called `default` in favour of
the new (multi-dtype friendly) way of the parent key (or if at root the empty string) plus `__` plus
the scalar type (typically string or int, fallback to unknown)
