### PR TITLE
anyOf union type support

### DIFF
--- a/genson-cli/err1.txt
+++ b/genson-cli/err1.txt
@@ -279,6 +279,81 @@ Schemas not homogeneous, attempting unification
 : Cannot unify incompatible scalar types: ["integer", "string"]
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(467 lines omitted)...
+    "zh-mo",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"de-ch":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"olo":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"be":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"lez":{"type":"string"},"ru":{"type":"string"},"pfl":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","ast","az","ba","be","be-tarask","bg","bn","bs","ca","cs","cy","da","dag","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","gu","he","hi","hr","hsb","ht","hu","hy","ia","id","ig","ilo","is","it","ja","ka","kaa","kk","ko","ky","la","lb","lez","lt","lv","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nl","nn","olo","or","pa","pfl","pl","pnb","pt","pt-br","ro","ru","scn","sco","se","sh","sk","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","ta","te","tg","tg-cyrl","th","tl","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 6 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 118 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 6 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 6 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 6 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -1475,6 +1550,107 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": [
+        "null",
+...(35 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(585 lines omitted)...
+    "lb",
+    "fa",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]},"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"zh-hant":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"be":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"frr":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"de-at":{"type":["null","string"]},"ha":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"bho":{"type":["null","string"]},"sc":{"type":["null","string"]},"br":{"type":["null","string"]},"kl":{"type":["null","string"]},"oc":{"type":["null","string"]},"ku":{"type":["null","string"]},"gpe":{"type":["null","string"]},"en-us":{"type":["null","string"]},"io":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"ps":{"type":["null","string"]},"diq":{"type":["null","string"]},"la":{"type":["null","string"]},"olo":{"type":["null","string"]},"an":{"type":["null","string"]},"ht":{"type":["null","string"]},"lez":{"type":["null","string"]},"pfl":{"type":["null","string"]},"mzn":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","pnb","de-ch","nds","zh-mo","sco","ro","bs","gl","ka","tt","zh-hant","sq","hr","en-ca","nl","af","nn","he","ar","ia","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","ig","sv","sr-el","be","bg","tr","ba","dag","eo","uk","el","zh-sg","scn","or","ta","zh-cn","xmf","uz","ky","is","da","pt-br","frr","zh-hk","zh-tw","ast","yue","az","te","es","ms","sms","lt","en-gb","vec","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","se","fi","cy","hu","ja","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","th","nap","ga","ru","et","gu","vi","tg","de","lb","fa","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 7 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 135 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 7 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": [
+        "null",
+...(35 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]},"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 7 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 7 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -2780,6 +2956,117 @@ Schemas not homogeneous, attempting unification
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(511 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(527 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"bs":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"jv":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"fi":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","ary","arz","as","ast","az","ba","be","be-tarask","bg","bho","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","inh","io","is","it","ja","jv","ka","kaa","kk","kn","ko","ks","ksh","la","lb","lt","lv","mg","min","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","sh","sk","sl","sq","sr","sr-ec","sr-el","sv","ta","tcy","te","tg","tg-cyrl","th","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "mni": {
+...(499 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 126 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 133 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -3613,6 +3900,45 @@ Converting field "qualifiers" to map with schema:
 }
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(347 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"tt-cyrl":{"type":"string"},"uz":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"be-tarask":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"nds":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ro":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"hr":{"type":"string"},"en":{"type":"string"},"hi":{"type":"string"},"gsw":{"type":"string"},"bs":{"type":"string"},"cs":{"type":"string"},"tt":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"ar":{"type":"string"},"cy":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"smn":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"kaa":{"type":"string"},"be":{"type":"string"},"id":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"ga":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"dag":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"ba":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"ku-latn":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"sk":{"type":"string"},"frr":{"type":"string"},"da":{"type":"string"}},"required":["af","ar","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","he","hi","hr","hsb","hu","id","it","ja","ka","kaa","ko","ku-latn","lb","lt","lv","mk","ms","ms-arab","my","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","se","sk","sl","smn","sms","sq","sr","sv","sw","tg","th","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 88 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
 Schemas not homogeneous, attempting unification
@@ -3829,6 +4155,117 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(111 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "zh-hk": {
+...(251 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"en":{"type":"string"},"fr":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"he":{"type":"string"},"pl":{"type":"string"},"ar":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"hu":{"type":"string"},"da":{"type":"string"},"de":{"type":"string"},"de-ch":{"type":"string"},"ca":{"type":"string"},"sv":{"type":"string"},"zh-hans":{"type":"string"},"zh-hant":{"type":"string"},"zh":{"type":"string"},"ko":{"type":"string"},"be-tarask":{"type":"string"},"nb":{"type":"string"},"gl":{"type":"string"},"zh-tw":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"be":{"type":"string"}},"required":["ar","be","be-tarask","ca","da","de","de-ch","en","es","fr","gl","he","hu","it","ja","ko","nb","pl","ru","sl","sv","uk","zh","zh-hans","zh-hant","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"be-tarask":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"en-gb":{"type":"string"},"zh-mo":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"bs":{"type":"string"},"tt":{"type":"string"},"ro":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"cy":{"type":"string"},"io":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"zh-my":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"id":{"type":"string"},"be":{"type":"string"},"tr":{"type":"string"},"ga":{"type":"string"},"eo":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"zh-sg":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"zh-cn":{"type":"string"},"fa":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","az","be","be-tarask","bn","bs","ca","cs","cy","da","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","he","hu","id","io","it","ja","ko","lb","lv","mk","ms","ms-arab","nb","nl","nn","pl","pnb","pt","pt-br","ro","ru","sl","sr","sv","tr","tt","uk","ur","vec","vi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "en": {
+      "type": "string"
+    },
+    "fr": {
+...(99 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"en":{"type":"string"},"fr":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"he":{"type":"string"},"pl":{"type":"string"},"ar":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"hu":{"type":"string"},"da":{"type":"string"},"de":{"type":"string"},"de-ch":{"type":"string"},"ca":{"type":"string"},"sv":{"type":"string"},"zh-hans":{"type":"string"},"zh-hant":{"type":"string"},"zh":{"type":"string"},"ko":{"type":"string"},"be-tarask":{"type":"string"},"nb":{"type":"string"},"gl":{"type":"string"},"zh-tw":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"be":{"type":"string"}},"required":["ar","be","be-tarask","ca","da","de","de-ch","en","es","fr","gl","he","hu","it","ja","ko","nb","pl","ru","sl","sv","uk","zh","zh-hans","zh-hant","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 26 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 64 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
@@ -5228,6 +5665,134 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -6985,6 +7550,45 @@ Converting field "qualifiers" to map with schema:
 }
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "zh-hk": {
+...(295 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"sr-ec":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"be-tarask":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"en-gb":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"sco":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"hsb":{"type":"string"},"ro":{"type":"string"},"ms-arab":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"he":{"type":"string"},"cy":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"zh-my":{"type":"string"},"eu":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"be":{"type":"string"},"sr-el":{"type":"string"},"sv":{"type":"string"},"id":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"ga":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"ba":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"zh-cn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","az","ba","be","be-tarask","bn","br","ca","cs","cy","da","dag","de","el","en","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","he","hsb","hu","hy","id","it","ja","ka","ko","lv","mk","ms","ms-arab","nb","nds","nl","nn","oc","pa","pl","pnb","pt","pt-br","ro","ru","scn","sco","sl","sq","sr","sr-ec","sr-el","sv","tg","tg-cyrl","tr","uk","ur","vec","vi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 75 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
 Schemas not homogeneous, attempting unification
@@ -7686,6 +8290,134 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "be-tarask": {
+      "type": "string"
+    },
+...(593 lines omitted)...
+    "ru",
+    "et",
+    "vi",
+    "de"
+  ]
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": [
+        "null",
+...(145 lines omitted)...
+        "null",
+        "object"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]},"id":{"type":["null","string"]},"labels":{"properties":{"pt":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"en":{"type":"string"},"hu":{"type":"string"},"fi":{"type":"string"},"it":{"type":"string"},"sw":{"type":"string"},"ja":{"type":"string"},"fa":{"type":"string"},"da":{"type":"string"},"nl":{"type":"string"},"ko":{"type":"string"},"pl":{"type":"string"},"ru":{"type":"string"},"pt-br":{"type":"string"},"de":{"type":"string"},"nb":{"type":"string"},"tr":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"sv":{"type":"string"},"ca":{"type":"string"},"eu":{"type":"string"},"uk":{"type":"string"}},"required":["ca","da","de","en","es","eu","fa","fi","fr","he","hu","it","ja","ko","nb","nl","nn","pl","pt","pt-br","ru","sv","sw","tr","uk"],"type":["null","object"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"de-ch":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"bs":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"nl":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"pl":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"da":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"yue":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"tt-cyrl":{"type":["null","string"]},"sr-ec":{"type":["null","string"]},"zh-mo":{"type":["null","string"]},"nds":{"type":["null","string"]},"sco":{"type":["null","string"]},"ka":{"type":["null","string"]},"diq":{"type":["null","string"]},"hr":{"type":["null","string"]},"en-ca":{"type":["null","string"]},"la":{"type":["null","string"]},"af":{"type":["null","string"]},"ia":{"type":["null","string"]},"eu":{"type":["null","string"]},"my":{"type":["null","string"]},"ml":{"type":["null","string"]},"olo":{"type":["null","string"]},"smn":{"type":["null","string"]},"hy":{"type":["null","string"]},"lv":{"type":["null","string"]},"pa":{"type":["null","string"]},"ig":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"bg":{"type":["null","string"]},"ba":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"scn":{"type":["null","string"]},"or":{"type":["null","string"]},"ta":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"frr":{"type":["null","string"]},"xmf":{"type":["null","string"]},"uz":{"type":["null","string"]},"ky":{"type":["null","string"]},"is":{"type":["null","string"]},"pt-br":{"type":["null","string"]},"zh-hk":{"type":["null","string"]},"az":{"type":["null","string"]},"te":{"type":["null","string"]},"sms":{"type":["null","string"]},"lt":{"type":["null","string"]},"mr":{"type":["null","string"]},"an":{"type":["null","string"]},"hsb":{"type":["null","string"]},"ms-arab":{"type":["null","string"]},"gsw":{"type":["null","string"]},"ur":{"type":["null","string"]},"tl":{"type":["null","string"]},"se":{"type":["null","string"]},"ht":{"type":["null","string"]},"tg-cyrl":{"type":["null","string"]},"kk":{"type":["null","string"]},"ilo":{"type":["null","string"]},"nap":{"type":["null","string"]},"ga":{"type":["null","string"]},"lez":{"type":["null","string"]},"pfl":{"type":["null","string"]},"gu":{"type":["null","string"]},"tg":{"type":["null","string"]},"lb":{"type":["null","string"]},"fa":{"type":["null","string"]},"mzn":{"type":["null","string"]},"sk":{"type":["null","string"]},"sh":{"type":["null","string"]}},"required":["be-tarask","it","nb","pnb","de-ch","ro","zh-hant","gl","bs","tt","sq","nl","he","nn","ar","sl","pl","pt","sv","be","tr","dag","eo","uk","el","da","zh-tw","ast","yue","es","ms","en-gb","vec","ko","hi","mk","ca","en","cs","fi","cy","hu","ja","sr","fr","bn","zh","zh-hans","kaa","id","th","ru","et","vi","de"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt": {
+      "type": "string"
+    },
+    "fr": {
+...(95 lines omitted)...
+    "sw",
+    "tr",
+    "uk"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 7 (NOT scalar): {"properties":{"pt":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"en":{"type":"string"},"hu":{"type":"string"},"fi":{"type":"string"},"it":{"type":"string"},"sw":{"type":"string"},"ja":{"type":"string"},"fa":{"type":"string"},"da":{"type":"string"},"nl":{"type":"string"},"ko":{"type":"string"},"pl":{"type":"string"},"ru":{"type":"string"},"pt-br":{"type":"string"},"de":{"type":"string"},"nb":{"type":"string"},"tr":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"sv":{"type":"string"},"ca":{"type":"string"},"eu":{"type":"string"},"uk":{"type":"string"}},"required":["ca","da","de","en","es","eu","fa","fi","fr","he","hu","it","ja","ko","nb","nl","nn","pl","pt","pt-br","ru","sv","sw","tr","uk"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 25 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 118 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 7 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]},"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 7 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 7 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -9345,6 +10077,127 @@ Converting field "qualifiers" to map with schema:
   }
 }
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "datavalue__string": {
+      "type": [
+        "null",
+...(1388 lines omitted)...
+    ]
+  },
+  "required": [
+    "datavalue__string"
+  ]
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "zh-hk": {
+      "type": "string"
+    },
+...(1021 lines omitted)...
+    "ru",
+    "uk",
+    "de",
+    "zh-cn"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"properties":{"dz":{"type":"string"},"tt-cyrl":{"type":"string"},"gcr":{"type":"string"},"rup":{"type":"string"},"nia":{"type":"string"},"pi":{"type":"string"},"ff":{"type":"string"},"be-tarask":{"type":"string"},"de-at":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ks":{"type":"string"},"ie":{"type":"string"},"ryu":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"ng":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ve":{"type":"string"},"tcy":{"type":"string"},"si":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"guw":{"type":"string"},"bxr":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"pam":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"ik":{"type":"string"},"azb":{"type":"string"},"os":{"type":"string"},"ml":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"mn":{"type":"string"},"olo":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"tt-latn":{"type":"string"},"ami":{"type":"string"},"sat":{"type":"string"},"pcm":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"wo":{"type":"string"},"ny":{"type":"string"},"tr":{"type":"string"},"ab":{"type":"string"},"eo":{"type":"string"},"br":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"kl":{"type":"string"},"is":{"type":"string"},"gn":{"type":"string"},"min":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"hyw":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"nv":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"nqo":{"type":"string"},"skr":{"type":"string"},"az":{"type":"string"},"nrm":{"type":"string"},"te":{"type":"string"},"guc":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"tw":{"type":"string"},"bm":{"type":"string"},"awa":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"got":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ku":{"type":"string"},"ko":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"jam":{"type":"string"},"gan":{"type":"string"},"xh":{"type":"string"},"btm":{"type":"string"},"lbe":{"type":"string"},"grc":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"mnw":{"type":"string"},"fj":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"udm":{"type":"string"},"tyv":{"type":"string"},"csb":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"jbo":{"type":"string"},"fr":{"type":"string"},"glk":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"arq":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"kr":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"krc":{"type":"string"},"tum":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"kg":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"sg":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"chr":{"type":"string"},"sh":{"type":"string"},"rw":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"om":{"type":"string"},"pih":{"type":"string"},"kcg":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"kbd":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"de-ch":{"type":"string"},"sd":{"type":"string"},"bi":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"hil":{"type":"string"},"bs":{"type":"string"},"blk":{"type":"string"},"sq":{"type":"string"},"lg":{"type":"string"},"mad":{"type":"string"},"yo":{"type":"string"},"mwl":{"type":"string"},"fur":{"type":"string"},"ee":{"type":"string"},"map-bms":{"type":"string"},"shn":{"type":"string"},"bho":{"type":"string"},"co":{"type":"string"},"arz":{"type":"string"},"ban":{"type":"string"},"ace":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"cbk-zam":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"za":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"bpy":{"type":"string"},"pag":{"type":"string"},"iu":{"type":"string"},"cr":{"type":"string"},"tk":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"gom":{"type":"string"},"bg":{"type":"string"},"dag":{"type":"string"},"shi":{"type":"string"},"lo":{"type":"string"},"myv":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"trv":{"type":"string"},"cu":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"gag":{"type":"string"},"da":{"type":"string"},"bo":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"mrj":{"type":"string"},"lmo":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"tpi":{"type":"string"},"dtp":{"type":"string"},"mg":{"type":"string"},"mai":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"gsw":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"bcl":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"rue":{"type":"string"},"lfn":{"type":"string"},"arc":{"type":"string"},"ss":{"type":"string"},"ja":{"type":"string"},"bug":{"type":"string"},"sr":{"type":"string"},"av":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"ty":{"type":"string"},"kn":{"type":"string"},"xal":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"brh":{"type":"string"},"tly":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"lez":{"type":"string"},"am":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"tok":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"bew":{"type":"string"},"roa-tara":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"ts":{"type":"string"},"de":{"type":"string"},"lad":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"bjn":{"type":"string"},"lij":{"type":"string"},"ltg":{"type":"string"},"kab":{"type":"string"},"ay":{"type":"string"}},"required":["ab","ace","ady","aeb-arab","af","am","ami","an","ang","anp","ar","arc","arq","ary","arz","as","ast","av","awa","ay","az","azb","ba","ban","bar","bbc","bcl","be","be-tarask","bew","bg","bho","bi","bjn","blk","bm","bn","bo","bpy","br","brh","bs","btm","bug","bxr","ca","cbk-zam","cdo","ce","ceb","chr","chy","ckb","co","cr","crh","crh-latn","cs","csb","cu","cv","cy","da","dag","de","de-at","de-ch","diq","dsb","dtp","dty","dv","dz","ee","el","eml","en","en-gb","en-us","eo","es","et","eu","ext","fa","ff","fi","fj","fo","fr","frp","frr","fur","fy","ga","gag","gan","gcr","gd","gl","glk","gn","gom","got","gpe","grc","gsw","gu","guc","guw","gv","ha","hak","haw","he","hi","hif","hil","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ig","ik","ilo","inh","io","is","it","iu","ja","jam","jbo","jv","ka","kaa","kab","kbd","kbp","kcg","kg","kk","kl","km","kn","ko","koi","kr","krc","ks","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lbe","lez","lfn","lg","li","lij","lld","lmo","ln","lo","lrc","lt","ltg","lv","lzh","mad","mai","map-bms","mdf","mg","mhr","mi","min","mk","ml","mn","mni","mnw","mr","mrj","ms","ms-arab","mt","mwl","my","myv","mzn","na","nah","nan","nap","nb","nds","nds-nl","ne","new","ng","nia","nl","nn","nov","nqo","nrm","nso","nv","ny","oc","olo","om","or","os","pa","pag","pam","pap","pcd","pcm","pdc","pfl","pi","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","rmf","ro","roa-tara","ru","rue","rup","rw","ryu","sa","sah","sat","sc","scn","sco","sd","se","sg","sgs","sh","shi","shn","si","sk","skr","sl","sm","smn","sms","sn","so","sq","sr","sr-ec","srn","ss","st","stq","su","sv","sw","syl","szl","ta","tcy","te","tg","tg-cyrl","th","ti","tk","tl","tly","tn","to","tok","tpi","tr","trv","ts","tt","tt-cyrl","tt-latn","tum","tw","ty","tyv","udm","ug","uk","ur","uz","ve","vec","vep","vi","vls","vo","vro","wa","war","wo","wuu","xal","xh","xmf","yi","yo","yue","za","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":["null","object"]}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"hi":{"type":"string"},"cs":{"type":"string"},"tt":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"fr":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"th":{"type":"string"},"dag":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"de":{"type":"string"},"zh-cn":{"type":"string"},"pt-br":{"type":["null","string"]},"tt-cyrl":{"type":["null","string"]},"uz":{"type":["null","string"]},"ast":{"type":["null","string"]},"az":{"type":["null","string"]},"yi":{"type":["null","string"]},"sms":{"type":["null","string"]},"lt":{"type":["null","string"]},"en-gb":{"type":["null","string"]},"vec":{"type":["null","string"]},"nds":{"type":["null","string"]},"ka":{"type":["null","string"]},"ro":{"type":["null","string"]},"hsb":{"type":["null","string"]},"ms-arab":{"type":["null","string"]},"sq":{"type":["null","string"]},"hr":{"type":["null","string"]},"gsw":{"type":["null","string"]},"bs":{"type":["null","string"]},"ur":{"type":["null","string"]},"en-ca":{"type":["null","string"]},"se":{"type":["null","string"]},"af":{"type":["null","string"]},"cy":{"type":["null","string"]},"he":{"type":["null","string"]},"eu":{"type":["null","string"]},"my":{"type":["null","string"]},"sr":{"type":["null","string"]},"smn":{"type":["null","string"]},"bn":{"type":["null","string"]},"lv":{"type":["null","string"]},"kaa":{"type":["null","string"]},"be":{"type":["null","string"]},"id":{"type":["null","string"]},"bg":{"type":["null","string"]},"ga":{"type":["null","string"]},"br":{"type":["null","string"]},"eo":{"type":["null","string"]},"ba":{"type":["null","string"]},"el":{"type":["null","string"]},"et":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"vi":{"type":["null","string"]},"tg":{"type":["null","string"]},"lb":{"type":["null","string"]},"fa":{"type":["null","string"]},"xmf":{"type":["null","string"]},"ckb":{"type":["null","string"]},"sk":{"type":["null","string"]},"frr":{"type":["null","string"]},"da":{"type":["null","string"]},"sw":["null",{"type":["null","string"]}],"sr-ec":["null",{"type":["null","string"]}],"kcg":["null",{"type":["null","string"]}],"ha":["null",{"type":["null","string"]}],"pnb":["null",{"type":["null","string"]}],"ks":["null",{"type":["null","string"]}],"zh-mo":["null",{"type":["null","string"]}],"sco":["null",{"type":["null","string"]}],"ce":["null",{"type":["null","string"]}],"diq":["null",{"type":["null","string"]}],"as":["null",{"type":["null","string"]}],"yo":["null",{"type":["null","string"]}],"ban":["null",{"type":["null","string"]}],"arz":["null",{"type":["null","string"]}],"pap":["null",{"type":["null","string"]}],"la":["null",{"type":["null","string"]}],"ia":["null",{"type":["null","string"]}],"sma":["null",{"type":["null","string"]}],"bar":["null",{"type":["null","string"]}],"ml":["null",{"type":["null","string"]}],"mhr":["null",{"type":["null","string"]}],"hy":["null",{"type":["null","string"]}],"pa":["null",{"type":["null","string"]}],"sah":["null",{"type":["null","string"]}],"ig":["null",{"type":["null","string"]}],"sr-el":["null",{"type":["null","string"]}],"no":["null",{"type":["null","string"]}],"zh-sg":["null",{"type":["null","string"]}],"or":["null",{"type":["null","string"]}],"scn":["null",{"type":["null","string"]}],"ta":["null",{"type":["null","string"]}],"ary":["null",{"type":["null","string"]}],"su":["null",{"type":["null","string"]}],"nqo":["null",{"type":["null","string"]}],"is":["null",{"type":["null","string"]}],"oc":["null",{"type":["null","string"]}],"yue":["null",{"type":["null","string"]}],"te":["null",{"type":["null","string"]}],"lmo":["null",{"type":["null","string"]}],"sjd":["null",{"type":["null","string"]}],"rmf":["null",{"type":["null","string"]}],"mr":["null",{"type":["null","string"]}],"mt":["null",{"type":["null","string"]}],"syl":["null",{"type":["null","string"]}],"tl":["null",{"type":["null","string"]}],"ti":["null",{"type":["null","string"]}],"udm":["null",{"type":["null","string"]}],"io":["null",{"type":["null","string"]}],"zh-my":["null",{"type":["null","string"]}],"tg-cyrl":["null",{"type":["null","string"]}],"nds-nl":["null",{"type":["null","string"]}],"kk":["null",{"type":["null","string"]}],"fy":["null",{"type":["null","string"]}],"ilo":["null",{"type":["null","string"]}],"tly":["null",{"type":["null","string"]}],"gd":["null",{"type":["null","string"]}],"ps":["null",{"type":["null","string"]}],"nap":["null",{"type":["null","string"]}],"pap-aw":["null",{"type":["null","string"]}],"tok":["null",{"type":["null","string"]}],"gu":["null",{"type":["null","string"]}],"smj":["null",{"type":["null","string"]}],"mzn":["null",{"type":["null","string"]}],"sh":["null",{"type":["null","string"]}]},"required":["zh-hk","zh-tw","be-tarask","it","es","ms","nb","ko","mk","zh-hant","gl","ca","en","hi","cs","tt","fi","nl","ar","nn","hu","ja","sl","fr","pl","zh","zh-hans","pt","sv","tr","th","dag","ru","uk","de","zh-cn"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "dz": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(1362 lines omitted)...
+  ],
+  "type": [
+    "null",
+    "object"
+  ]
+}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"properties":{"dz":{"type":"string"},"tt-cyrl":{"type":"string"},"gcr":{"type":"string"},"rup":{"type":"string"},"nia":{"type":"string"},"pi":{"type":"string"},"ff":{"type":"string"},"be-tarask":{"type":"string"},"de-at":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ks":{"type":"string"},"ie":{"type":"string"},"ryu":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"ng":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ve":{"type":"string"},"tcy":{"type":"string"},"si":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"guw":{"type":"string"},"bxr":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"pam":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"ik":{"type":"string"},"azb":{"type":"string"},"os":{"type":"string"},"ml":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"mn":{"type":"string"},"olo":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"tt-latn":{"type":"string"},"ami":{"type":"string"},"sat":{"type":"string"},"pcm":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"wo":{"type":"string"},"ny":{"type":"string"},"tr":{"type":"string"},"ab":{"type":"string"},"eo":{"type":"string"},"br":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"kl":{"type":"string"},"is":{"type":"string"},"gn":{"type":"string"},"min":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"hyw":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"nv":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"nqo":{"type":"string"},"skr":{"type":"string"},"az":{"type":"string"},"nrm":{"type":"string"},"te":{"type":"string"},"guc":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"tw":{"type":"string"},"bm":{"type":"string"},"awa":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"got":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ku":{"type":"string"},"ko":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"jam":{"type":"string"},"gan":{"type":"string"},"xh":{"type":"string"},"btm":{"type":"string"},"lbe":{"type":"string"},"grc":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"mnw":{"type":"string"},"fj":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"udm":{"type":"string"},"tyv":{"type":"string"},"csb":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"jbo":{"type":"string"},"fr":{"type":"string"},"glk":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"arq":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"kr":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"krc":{"type":"string"},"tum":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"kg":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"sg":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"chr":{"type":"string"},"sh":{"type":"string"},"rw":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"om":{"type":"string"},"pih":{"type":"string"},"kcg":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"kbd":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"de-ch":{"type":"string"},"sd":{"type":"string"},"bi":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"hil":{"type":"string"},"bs":{"type":"string"},"blk":{"type":"string"},"sq":{"type":"string"},"lg":{"type":"string"},"mad":{"type":"string"},"yo":{"type":"string"},"mwl":{"type":"string"},"fur":{"type":"string"},"ee":{"type":"string"},"map-bms":{"type":"string"},"shn":{"type":"string"},"bho":{"type":"string"},"co":{"type":"string"},"arz":{"type":"string"},"ban":{"type":"string"},"ace":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"cbk-zam":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"za":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"bpy":{"type":"string"},"pag":{"type":"string"},"iu":{"type":"string"},"cr":{"type":"string"},"tk":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"gom":{"type":"string"},"bg":{"type":"string"},"dag":{"type":"string"},"shi":{"type":"string"},"lo":{"type":"string"},"myv":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"trv":{"type":"string"},"cu":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"gag":{"type":"string"},"da":{"type":"string"},"bo":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"mrj":{"type":"string"},"lmo":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"tpi":{"type":"string"},"dtp":{"type":"string"},"mg":{"type":"string"},"mai":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"gsw":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"bcl":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"rue":{"type":"string"},"lfn":{"type":"string"},"arc":{"type":"string"},"ss":{"type":"string"},"ja":{"type":"string"},"bug":{"type":"string"},"sr":{"type":"string"},"av":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"ty":{"type":"string"},"kn":{"type":"string"},"xal":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"brh":{"type":"string"},"tly":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"lez":{"type":"string"},"am":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"tok":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"bew":{"type":"string"},"roa-tara":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"ts":{"type":"string"},"de":{"type":"string"},"lad":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"bjn":{"type":"string"},"lij":{"type":"string"},"ltg":{"type":"string"},"kab":{"type":"string"},"ay":{"type":"string"}},"required":["ab","ace","ady","aeb-arab","af","am","ami","an","ang","anp","ar","arc","arq","ary","arz","as","ast","av","awa","ay","az","azb","ba","ban","bar","bbc","bcl","be","be-tarask","bew","bg","bho","bi","bjn","blk","bm","bn","bo","bpy","br","brh","bs","btm","bug","bxr","ca","cbk-zam","cdo","ce","ceb","chr","chy","ckb","co","cr","crh","crh-latn","cs","csb","cu","cv","cy","da","dag","de","de-at","de-ch","diq","dsb","dtp","dty","dv","dz","ee","el","eml","en","en-gb","en-us","eo","es","et","eu","ext","fa","ff","fi","fj","fo","fr","frp","frr","fur","fy","ga","gag","gan","gcr","gd","gl","glk","gn","gom","got","gpe","grc","gsw","gu","guc","guw","gv","ha","hak","haw","he","hi","hif","hil","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ig","ik","ilo","inh","io","is","it","iu","ja","jam","jbo","jv","ka","kaa","kab","kbd","kbp","kcg","kg","kk","kl","km","kn","ko","koi","kr","krc","ks","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lbe","lez","lfn","lg","li","lij","lld","lmo","ln","lo","lrc","lt","ltg","lv","lzh","mad","mai","map-bms","mdf","mg","mhr","mi","min","mk","ml","mn","mni","mnw","mr","mrj","ms","ms-arab","mt","mwl","my","myv","mzn","na","nah","nan","nap","nb","nds","nds-nl","ne","new","ng","nia","nl","nn","nov","nqo","nrm","nso","nv","ny","oc","olo","om","or","os","pa","pag","pam","pap","pcd","pcm","pdc","pfl","pi","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","rmf","ro","roa-tara","ru","rue","rup","rw","ryu","sa","sah","sat","sc","scn","sco","sd","se","sg","sgs","sh","shi","shn","si","sk","skr","sl","sm","smn","sms","sn","so","sq","sr","sr-ec","srn","ss","st","stq","su","sv","sw","syl","szl","ta","tcy","te","tg","tg-cyrl","th","ti","tk","tl","tly","tn","to","tok","tpi","tr","trv","ts","tt","tt-cyrl","tt-latn","tum","tw","ty","tyv","udm","ug","uk","ur","uz","ve","vec","vep","vi","vls","vo","vro","wa","war","wo","wuu","xal","xh","xmf","yi","yo","yue","za","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":["null","object"]}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 341 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "root" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 151 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"string"}
+  Schema 1: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+property-labels: All schemas are scalars, attempting scalar unification
+property-labels: Unified scalar schemas to nullable string
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": [
+    "null",
+    "string"
+  ]
+}
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1: {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -9983,6 +10836,117 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "hu": {
+      "type": "string"
+    },
+    "ja": {
+...(159 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(283 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"pt-br":{"type":"string"},"dv":{"type":"string"},"sk":{"type":"string"},"li":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"de-ch":{"type":"string"},"ko":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"gl":{"type":"string"},"ro":{"type":"string"},"si":{"type":"string"},"zh-hant":{"type":"string"},"hr":{"type":"string"},"ca":{"type":"string"},"sq":{"type":"string"},"en":{"type":"string"},"gsw":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"cy":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"mn":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"lv":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"id":{"type":"string"},"sv":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ga":{"type":"string"},"eo":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"uz":{"type":"string"},"sh":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","bg","bn","ca","cs","cy","da","de","de-ch","dv","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gsw","he","hi","hr","hu","id","is","it","ja","ko","li","lt","lv","mk","mn","ms","nb","nl","nn","oc","pl","pnb","pt","pt-br","ro","ru","sh","si","sk","sl","sq","sr","sv","sw","th","tr","uk","ur","uz","vi","wuu","zh","zh-hans","zh-hant","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"hi":{"type":"string"},"gl":{"type":"string"},"ga":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"de":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"zh-cn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"da":{"type":"string"}},"required":["ar","be-tarask","ca","cs","da","de","el","en","es","et","fi","fr","ga","gl","he","hi","hu","it","ja","ko","mk","ms","ms-arab","nb","nl","pl","pt","pt-br","ru","sk","sl","sr","sv","tr","uk","ur","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "dv": {
+...(271 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"dv":{"type":"string"},"sk":{"type":"string"},"li":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"de-ch":{"type":"string"},"ko":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"gl":{"type":"string"},"ro":{"type":"string"},"si":{"type":"string"},"zh-hant":{"type":"string"},"hr":{"type":"string"},"ca":{"type":"string"},"sq":{"type":"string"},"en":{"type":"string"},"gsw":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"cy":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"mn":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"lv":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"id":{"type":"string"},"sv":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ga":{"type":"string"},"eo":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"uz":{"type":"string"},"sh":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","bg","bn","ca","cs","cy","da","de","de-ch","dv","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gsw","he","hi","hr","hu","id","is","it","ja","ko","li","lt","lv","mk","mn","ms","nb","nl","nn","oc","pl","pnb","pt","pt-br","ro","ru","sh","si","sk","sl","sq","sr","sv","sw","th","tr","uk","ur","uz","vi","wuu","zh","zh-hans","zh-hant","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 69 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 41 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}

--- a/genson-cli/err2.txt
+++ b/genson-cli/err2.txt
@@ -403,6 +403,134 @@ Schemas not homogeneous, attempting unification
 : Not all schemas are scalars
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "qualifiers" with 1 schemas
 Unique normalised schemas (1 total):
   Schema 0:
@@ -436,6 +564,1471 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(463 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(595 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "mni": {
+      "type": "string"
+    },
+    "be-tarask": {
+...(451 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 114 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 150 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1: {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(463 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(595 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "mni": {
+      "type": "string"
+    },
+    "be-tarask": {
+...(451 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 114 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 150 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 0 (NOT scalar): {"type":"object","properties":{"property":{"type":"string"},"datavalue":{"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]},"datatype":{"type":"string"},"property-labels":{"type":"object","additionalProperties":{"type":["null","string"]}}},"required":["property","datavalue","datatype","property-labels"]}
+  Schema 2 (NOT scalar): {"type":["null","array"],"items":{"type":"object","additionalProperties":{"type":"array","items":{"type":"object","properties":{"property":{"type":"string"},"datavalue":{"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}},"datatype":{"type":"string"},"property-labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["property","datavalue","datatype","property-labels"]}}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"array","items":{"properties":{"property":{"type":"string"},"datavalue":{"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"},"datatype":{"type":"string"},"property-labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["datatype","datavalue","property","property-labels"],"type":"object"}}}
+Not converting to map: no unified schema
+Checking homogeneity for field "mainsnak" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1: {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+mainsnak: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1: {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 0 (NOT scalar): {"type":"object","properties":{"property":{"type":"string"},"datavalue":{"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":["null","object"],"properties":{"zh-hk":{"type":"string"},"ast":{"type":"string"},"es":{"type":"string"},"nb":{"type":"string"},"zh-hant":{"type":"string"},"en":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"fr":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"be":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"et":{"type":"string"},"ta":{"type":"string"},"vi":{"type":"string"},"sk":{"type":["null","string"]},"gn":{"type":["null","string"]},"li":{"type":["null","string"]},"is":{"type":["null","string"]},"min":{"type":["null","string"]},"zh-tw":{"type":["null","string"]},"sr-ec":{"type":["null","string"]},"oc":{"type":["null","string"]},"be-tarask":{"type":["null","string"]},"az":{"type":["null","string"]},"yue":{"type":["null","string"]},"kab":{"type":["null","string"]},"it":{"type":["null","string"]},"ms":{"type":["null","string"]},"yi":{"type":["null","string"]},"wuu":{"type":["null","string"]},"pt-br":{"type":["null","string"]},"lt":{"type":["null","string"]},"om":{"type":["null","string"]},"war":{"type":["null","string"]},"nds":{"type":["null","string"]},"ko":{"type":["null","string"]},"ku":{"type":["null","string"]},"sco":{"type":["null","string"]},"bs":{"type":["null","string"]},"hi":{"type":["null","string"]},"ro":{"type":["null","string"]},"gl":{"type":["null","string"]},"jam":{"type":["null","string"]},"tt":{"type":["null","string"]},"hr":{"type":["null","string"]},"ca":{"type":["null","string"]},"si":{"type":["null","string"]},"wa":{"type":["null","string"]},"as":{"type":["null","string"]},"mk":{"type":["null","string"]},"cs":{"type":["null","string"]},"ur":{"type":["null","string"]},"se":{"type":["null","string"]},"fi":{"type":["null","string"]},"arz":{"type":["null","string"]},"nl":{"type":["null","string"]},"la":{"type":["null","string"]},"ar":{"type":["null","string"]},"he":{"type":["null","string"]},"io":{"type":["null","string"]},"cy":{"type":["null","string"]},"tyv":{"type":["null","string"]},"sl":{"type":["null","string"]},"eu":{"type":["null","string"]},"nn":{"type":["null","string"]},"af":{"type":["null","string"]},"bcl":{"type":["null","string"]},"sr":{"type":["null","string"]},"ml":{"type":["null","string"]},"azb":{"type":["null","string"]},"mn":{"type":["null","string"]},"kk":{"type":["null","string"]},"bn":{"type":["null","string"]},"pl":{"type":["null","string"]},"lv":{"type":["null","string"]},"hy":{"type":["null","string"]},"sv":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"tr":{"type":["null","string"]},"ps":{"type":["null","string"]},"id":{"type":["null","string"]},"ga":{"type":["null","string"]},"eo":{"type":["null","string"]},"nan":{"type":["null","string"]},"el":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"tg":{"type":["null","string"]},"de":{"type":["null","string"]},"ary":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"fa":{"type":["null","string"]},"uz":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"sh":{"type":["null","string"]},"da":{"type":["null","string"]}},"required":["zh-hk","ast","es","nb","zh-hant","en","hu","ja","fr","zh","zh-hans","pt","th","bg","be","ru","uk","et","ta","vi"]}]},"required":["datavalue__string"]},"datatype":{"type":"string"},"property-labels":{"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"zh-hant":{"type":"string"},"nl":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"pl":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"da":{"type":"string"},"zh-tw":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"ru":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"pt-br":{"type":["null","string"]},"pnb":{"type":["null","string"]},"br":{"type":["null","string"]},"en-gb":{"type":["null","string"]},"ro":{"type":["null","string"]},"nn":{"type":["null","string"]},"ba":{"type":["null","string"]},"ast":{"type":["null","string"]},"sms":{"type":["null","string"]},"ur":{"type":["null","string"]},"ps":{"type":["null","string"]},"be":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"vi":{"type":["null","string"]},"hy":{"type":["null","string"]},"nqo":{"type":["null","string"]},"sco":{"type":["null","string"]},"hr":{"type":["null","string"]},"sq":{"type":["null","string"]},"ml":{"type":["null","string"]},"smn":{"type":["null","string"]},"zh-hk":{"type":["null","string"]},"oc":{"type":["null","string"]},"te":{"type":["null","string"]},"az":{"type":["null","string"]},"se":{"type":["null","string"]},"th":{"type":["null","string"]},"tg":{"type":["null","string"]},"ga":{"type":["null","string"]},"nds":{"type":["null","string"]},"ka":{"type":["null","string"]},"bg":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"ig":{"type":["null","string"]},"szl":{"type":["null","string"]},"or":{"type":["null","string"]},"scn":{"type":["null","string"]},"ta":{"type":["null","string"]},"ckb":{"type":["null","string"]},"is":{"type":["null","string"]},"lt":{"type":["null","string"]},"mr":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"ilo":{"type":["null","string"]},"et":{"type":["null","string"]},"gu":{"type":["null","string"]},"lb":{"type":["null","string"]},"sk":{"type":["null","string"]},"sh":{"type":["null","string"]},"my":{"type":["null","string"]},"pa":{"type":["null","string"]},"min":{"type":["null","string"]},"hsb":{"type":["null","string"]},"sc":{"type":["null","string"]},"os":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"tok":{"type":["null","string"]},"io":{"type":["null","string"]},"syl":{"type":["null","string"]},"hi":{"type":["null","string"]},"tg-cyrl":{"type":["null","string"]},"zh-mo":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"yi":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"en-ca":{"type":["null","string"]},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"af":{"type":["null","string"]},"jv":{"type":["null","string"]},"tt-latn":{"type":["null","string"]},"xmf":{"type":["null","string"]},"yue":{"type":["null","string"]},"mg":{"type":["null","string"]},"ne":{"type":["null","string"]},"gsw":{"type":["null","string"]},"tl":{"type":["null","string"]},"kk":{"type":["null","string"]},"kaa":{"type":["null","string"]},"ksh":{"type":["null","string"]},"sd":{"type":["null","string"]},"diq":{"type":["null","string"]},"yo":{"type":["null","string"]},"pap":{"type":["null","string"]},"ia":{"type":["null","string"]},"bar":{"type":["null","string"]},"frr":{"type":["null","string"]},"uz":{"type":["null","string"]},"ky":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"nds-nl":{"type":["null","string"]},"gd":{"type":["null","string"]},"mzn":{"type":["null","string"]},"si":{"type":["null","string"]},"de-at":{"type":["null","string"]},"de-ch":{"type":["null","string"]},"co":{"type":["null","string"]},"pam":{"type":["null","string"]},"pcm":{"type":["null","string"]},"pcd":{"type":["null","string"]},"rm":{"type":["null","string"]},"ts":{"type":["null","string"]},"ha":["null",{"type":["null","string"]}],"gn":["null",{"type":["null","string"]}],"gpe":["null",{"type":["null","string"]}],"bho":["null",{"type":["null","string"]}],"lo":["null",{"type":["null","string"]}],"nan":["null",{"type":["null","string"]}],"en-us":["null",{"type":["null","string"]}],"kcg":["null",{"type":["null","string"]}],"rgn":["null",{"type":["null","string"]}],"tcy":["null",{"type":["null","string"]}],"ban":["null",{"type":["null","string"]}],"dga":["null",{"type":["null","string"]}],"mn":["null",{"type":["null","string"]}],"sa":["null",{"type":["null","string"]}],"tg-latn":["null",{"type":["null","string"]}],"udm":["null",{"type":["null","string"]}],"lfn":["null",{"type":["null","string"]}],"rue":["null",{"type":["null","string"]}],"jbo":["null",{"type":["null","string"]}],"tly":["null",{"type":["null","string"]}],"am":["null",{"type":["null","string"]}],"pap-aw":["null",{"type":["null","string"]}],"ht":["null",{"type":["null","string"]}],"km":["null",{"type":["null","string"]}],"cdo":["null",{"type":["null","string"]}],"ryu":["null",{"type":["null","string"]}],"ban-bali":["null",{"type":["null","string"]}],"hil":["null",{"type":["null","string"]}],"bxr":["null",{"type":["null","string"]}],"as":["null",{"type":["null","string"]}],"guw":["null",{"type":["null","string"]}],"sah":["null",{"type":["null","string"]}],"sat":["null",{"type":["null","string"]}],"szy":["null",{"type":["null","string"]}],"no":["null",{"type":["null","string"]}],"ary":["null",{"type":["null","string"]}],"su":["null",{"type":["null","string"]}],"vo":["null",{"type":["null","string"]}],"lmo":["null",{"type":["null","string"]}],"mai":["null",{"type":["null","string"]}],"wa":["null",{"type":["null","string"]}],"ti":["null",{"type":["null","string"]}],"csb":["null",{"type":["null","string"]}],"hak":["null",{"type":["null","string"]}],"nan-hani":["null",{"type":["null","string"]}],"nap":["null",{"type":["null","string"]}],"zu":["null",{"type":["null","string"]}],"kv":["null",{"type":["null","string"]}],"mdf":["null",{"type":["null","string"]}],"stq":["null",{"type":["null","string"]}],"glk":["null",{"type":["null","string"]}],"ab":["null",{"type":["null","string"]}],"atj":["null",{"type":["null","string"]}],"frp":["null",{"type":["null","string"]}],"arq":["null",{"type":["null","string"]}],"kab":["null",{"type":["null","string"]}],"ak":["null",{"type":["null","string"]}],"aln":["null",{"type":["null","string"]}],"ku-arab":{"type":["null","string"]},"hyw":{"type":["null","string"]},"lzz":{"type":["null","string"]},"new":{"type":["null","string"]},"ku":{"type":["null","string"]},"inh":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","bs","gl","tt","zh-hant","nl","he","ar","sl","eu","pl","lv","pt","sv","tr","dag","eo","uk","el","da","zh-tw","es","ms","vec","ko","mk","ms-arab","ca","en","cs","fi","cy","hu","ja","sr","fr","bn","zh","zh-hans","id","ru","de","fa","pt-br","pnb","br","en-gb","ro","nn","ba","ast","sms","ur","ps","be","zh-cn","vi","hy","nqo","sco","hr","sq","ml","smn","zh-hk","oc","te","az","se","th","tg","ga","nds","ka","bg","sr-el","ig","szl","or","scn","ta","ckb","is","lt","mr","kn","fy","ilo","et","gu","lb","sk","sh","my","pa","min","hsb","sc","os","ku-latn","tok","io","syl","hi","tg-cyrl","zh-mo","zh-sg","zh-my","yi","ks","ce","en-ca","arz","la","af","jv","tt-latn","xmf","yue","mg","ne","gsw","tl","kk","kaa","ksh","sd","diq","yo","pap","ia","bar","frr","uz","ky","an","mt","kw","sw","fo","nds-nl","gd","mzn","si","de-at","de-ch","co","pam","pcm","pcd","rm","ts"]}},"required":["property","datavalue","datatype","property-labels"]}
+  Schema 2 (NOT scalar): {"type":["null","array"],"items":{"properties":{"P248":{"type":"array","items":{"properties":{"property":{"type":"string"},"datavalue":{"properties":{"id":{"type":"string"},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"},"datatype":{"type":"string"},"property-labels":{"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"pfl":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","arz","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ce","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","gu","he","hi","hr","hsb","hu","hy","ia","id","ilo","is","it","ja","ka","kaa","kk","ko","ks","la","lb","lt","lv","mg","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nl","nn","oc","or","pa","pfl","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","se","sh","sk","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","te","tg","tg-cyrl","th","tl","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}},"required":["datatype","datavalue","property","property-labels"],"type":"object"}},"P577":{"type":"array","items":{"properties":{"property":{"type":"string"},"datavalue":{"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"},"datatype":{"type":"string"},"property-labels":{"properties":{"tt-cyrl":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"zh-hant":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"diq":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"lo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"shi":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"ky":{"type":"string"},"nqo":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"xmf":{"type":"string"},"skr":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"mt":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"rue":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"nap":{"type":"string"},"ps":{"type":"string"},"crh":{"type":"string"},"ga":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"mi":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"dsb":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","as","ast","az","ba","ban","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","crh","cs","cy","da","dag","de","diq","dsb","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","id","ig","ilo","it","ja","ka","kaa","kcg","kk","km","kn","ko","ks","ku-latn","kw","ky","lb","lo","lt","lv","mg","mi","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","ne","nl","nn","no","nqo","oc","or","pa","pap","pl","pnb","ps","pt","pt-br","ro","ru","rue","sah","scn","sco","sh","shi","sk","skr","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","sw","ta","te","tg","tg-cyrl","th","tl","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}},"required":["datatype","datavalue","property","property-labels"],"type":"object"}}},"required":["P248","P577"],"type":"object"}}
+  Schema 3 (NOT scalar): {"properties":{"P407":{"type":"array","items":{"properties":{"property":{"type":"string"},"datavalue":{"properties":{"id":{"type":"string"},"labels":{"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"},"datatype":{"type":"string"},"property-labels":{"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}},"required":["datatype","datavalue","property","property-labels"],"type":"object"}}},"required":["P407"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "mainsnak" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "datavalue__string": {
+      "type": [
+        "null",
+...(596 lines omitted)...
+    ]
+  },
+  "required": [
+    "datavalue__string"
+  ]
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(1504 lines omitted)...
+    "pcm",
+    "pcd",
+    "rm",
+    "ts"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+mainsnak: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"datavalue__string":{"type":["null","string"]},"id":["null",{"type":["null","string"]}],"labels":["null",{"type":["null","object"],"properties":{"zh-hk":{"type":"string"},"ast":{"type":"string"},"es":{"type":"string"},"nb":{"type":"string"},"zh-hant":{"type":"string"},"en":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"fr":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"be":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"et":{"type":"string"},"ta":{"type":"string"},"vi":{"type":"string"},"sk":{"type":["null","string"]},"gn":{"type":["null","string"]},"li":{"type":["null","string"]},"is":{"type":["null","string"]},"min":{"type":["null","string"]},"zh-tw":{"type":["null","string"]},"sr-ec":{"type":["null","string"]},"oc":{"type":["null","string"]},"be-tarask":{"type":["null","string"]},"az":{"type":["null","string"]},"yue":{"type":["null","string"]},"kab":{"type":["null","string"]},"it":{"type":["null","string"]},"ms":{"type":["null","string"]},"yi":{"type":["null","string"]},"wuu":{"type":["null","string"]},"pt-br":{"type":["null","string"]},"lt":{"type":["null","string"]},"om":{"type":["null","string"]},"war":{"type":["null","string"]},"nds":{"type":["null","string"]},"ko":{"type":["null","string"]},"ku":{"type":["null","string"]},"sco":{"type":["null","string"]},"bs":{"type":["null","string"]},"hi":{"type":["null","string"]},"ro":{"type":["null","string"]},"gl":{"type":["null","string"]},"jam":{"type":["null","string"]},"tt":{"type":["null","string"]},"hr":{"type":["null","string"]},"ca":{"type":["null","string"]},"si":{"type":["null","string"]},"wa":{"type":["null","string"]},"as":{"type":["null","string"]},"mk":{"type":["null","string"]},"cs":{"type":["null","string"]},"ur":{"type":["null","string"]},"se":{"type":["null","string"]},"fi":{"type":["null","string"]},"arz":{"type":["null","string"]},"nl":{"type":["null","string"]},"la":{"type":["null","string"]},"ar":{"type":["null","string"]},"he":{"type":["null","string"]},"io":{"type":["null","string"]},"cy":{"type":["null","string"]},"tyv":{"type":["null","string"]},"sl":{"type":["null","string"]},"eu":{"type":["null","string"]},"nn":{"type":["null","string"]},"af":{"type":["null","string"]},"bcl":{"type":["null","string"]},"sr":{"type":["null","string"]},"ml":{"type":["null","string"]},"azb":{"type":["null","string"]},"mn":{"type":["null","string"]},"kk":{"type":["null","string"]},"bn":{"type":["null","string"]},"pl":{"type":["null","string"]},"lv":{"type":["null","string"]},"hy":{"type":["null","string"]},"sv":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"tr":{"type":["null","string"]},"ps":{"type":["null","string"]},"id":{"type":["null","string"]},"ga":{"type":["null","string"]},"eo":{"type":["null","string"]},"nan":{"type":["null","string"]},"el":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"tg":{"type":["null","string"]},"de":{"type":["null","string"]},"ary":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"fa":{"type":["null","string"]},"uz":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"sh":{"type":["null","string"]},"da":{"type":["null","string"]}},"required":["zh-hk","ast","es","nb","zh-hant","en","hu","ja","fr","zh","zh-hans","pt","th","bg","be","ru","uk","et","ta","vi"]}]},"required":["datavalue__string"]}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"zh-hant":{"type":"string"},"nl":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"pl":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"da":{"type":"string"},"zh-tw":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"ru":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"pt-br":{"type":["null","string"]},"pnb":{"type":["null","string"]},"br":{"type":["null","string"]},"en-gb":{"type":["null","string"]},"ro":{"type":["null","string"]},"nn":{"type":["null","string"]},"ba":{"type":["null","string"]},"ast":{"type":["null","string"]},"sms":{"type":["null","string"]},"ur":{"type":["null","string"]},"ps":{"type":["null","string"]},"be":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"vi":{"type":["null","string"]},"hy":{"type":["null","string"]},"nqo":{"type":["null","string"]},"sco":{"type":["null","string"]},"hr":{"type":["null","string"]},"sq":{"type":["null","string"]},"ml":{"type":["null","string"]},"smn":{"type":["null","string"]},"zh-hk":{"type":["null","string"]},"oc":{"type":["null","string"]},"te":{"type":["null","string"]},"az":{"type":["null","string"]},"se":{"type":["null","string"]},"th":{"type":["null","string"]},"tg":{"type":["null","string"]},"ga":{"type":["null","string"]},"nds":{"type":["null","string"]},"ka":{"type":["null","string"]},"bg":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"ig":{"type":["null","string"]},"szl":{"type":["null","string"]},"or":{"type":["null","string"]},"scn":{"type":["null","string"]},"ta":{"type":["null","string"]},"ckb":{"type":["null","string"]},"is":{"type":["null","string"]},"lt":{"type":["null","string"]},"mr":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"ilo":{"type":["null","string"]},"et":{"type":["null","string"]},"gu":{"type":["null","string"]},"lb":{"type":["null","string"]},"sk":{"type":["null","string"]},"sh":{"type":["null","string"]},"my":{"type":["null","string"]},"pa":{"type":["null","string"]},"min":{"type":["null","string"]},"hsb":{"type":["null","string"]},"sc":{"type":["null","string"]},"os":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"tok":{"type":["null","string"]},"io":{"type":["null","string"]},"syl":{"type":["null","string"]},"hi":{"type":["null","string"]},"tg-cyrl":{"type":["null","string"]},"zh-mo":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"yi":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"en-ca":{"type":["null","string"]},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"af":{"type":["null","string"]},"jv":{"type":["null","string"]},"tt-latn":{"type":["null","string"]},"xmf":{"type":["null","string"]},"yue":{"type":["null","string"]},"mg":{"type":["null","string"]},"ne":{"type":["null","string"]},"gsw":{"type":["null","string"]},"tl":{"type":["null","string"]},"kk":{"type":["null","string"]},"kaa":{"type":["null","string"]},"ksh":{"type":["null","string"]},"sd":{"type":["null","string"]},"diq":{"type":["null","string"]},"yo":{"type":["null","string"]},"pap":{"type":["null","string"]},"ia":{"type":["null","string"]},"bar":{"type":["null","string"]},"frr":{"type":["null","string"]},"uz":{"type":["null","string"]},"ky":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"nds-nl":{"type":["null","string"]},"gd":{"type":["null","string"]},"mzn":{"type":["null","string"]},"si":{"type":["null","string"]},"de-at":{"type":["null","string"]},"de-ch":{"type":["null","string"]},"co":{"type":["null","string"]},"pam":{"type":["null","string"]},"pcm":{"type":["null","string"]},"pcd":{"type":["null","string"]},"rm":{"type":["null","string"]},"ts":{"type":["null","string"]},"ha":["null",{"type":["null","string"]}],"gn":["null",{"type":["null","string"]}],"gpe":["null",{"type":["null","string"]}],"bho":["null",{"type":["null","string"]}],"lo":["null",{"type":["null","string"]}],"nan":["null",{"type":["null","string"]}],"en-us":["null",{"type":["null","string"]}],"kcg":["null",{"type":["null","string"]}],"rgn":["null",{"type":["null","string"]}],"tcy":["null",{"type":["null","string"]}],"ban":["null",{"type":["null","string"]}],"dga":["null",{"type":["null","string"]}],"mn":["null",{"type":["null","string"]}],"sa":["null",{"type":["null","string"]}],"tg-latn":["null",{"type":["null","string"]}],"udm":["null",{"type":["null","string"]}],"lfn":["null",{"type":["null","string"]}],"rue":["null",{"type":["null","string"]}],"jbo":["null",{"type":["null","string"]}],"tly":["null",{"type":["null","string"]}],"am":["null",{"type":["null","string"]}],"pap-aw":["null",{"type":["null","string"]}],"ht":["null",{"type":["null","string"]}],"km":["null",{"type":["null","string"]}],"cdo":["null",{"type":["null","string"]}],"ryu":["null",{"type":["null","string"]}],"ban-bali":["null",{"type":["null","string"]}],"hil":["null",{"type":["null","string"]}],"bxr":["null",{"type":["null","string"]}],"as":["null",{"type":["null","string"]}],"guw":["null",{"type":["null","string"]}],"sah":["null",{"type":["null","string"]}],"sat":["null",{"type":["null","string"]}],"szy":["null",{"type":["null","string"]}],"no":["null",{"type":["null","string"]}],"ary":["null",{"type":["null","string"]}],"su":["null",{"type":["null","string"]}],"vo":["null",{"type":["null","string"]}],"lmo":["null",{"type":["null","string"]}],"mai":["null",{"type":["null","string"]}],"wa":["null",{"type":["null","string"]}],"ti":["null",{"type":["null","string"]}],"csb":["null",{"type":["null","string"]}],"hak":["null",{"type":["null","string"]}],"nan-hani":["null",{"type":["null","string"]}],"nap":["null",{"type":["null","string"]}],"zu":["null",{"type":["null","string"]}],"kv":["null",{"type":["null","string"]}],"mdf":["null",{"type":["null","string"]}],"stq":["null",{"type":["null","string"]}],"glk":["null",{"type":["null","string"]}],"ab":["null",{"type":["null","string"]}],"atj":["null",{"type":["null","string"]}],"frp":["null",{"type":["null","string"]}],"arq":["null",{"type":["null","string"]}],"kab":["null",{"type":["null","string"]}],"ak":["null",{"type":["null","string"]}],"aln":["null",{"type":["null","string"]}],"ku-arab":{"type":["null","string"]},"hyw":{"type":["null","string"]},"lzz":{"type":["null","string"]},"new":{"type":["null","string"]},"ku":{"type":["null","string"]},"inh":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","bs","gl","tt","zh-hant","nl","he","ar","sl","eu","pl","lv","pt","sv","tr","dag","eo","uk","el","da","zh-tw","es","ms","vec","ko","mk","ms-arab","ca","en","cs","fi","cy","hu","ja","sr","fr","bn","zh","zh-hans","id","ru","de","fa","pt-br","pnb","br","en-gb","ro","nn","ba","ast","sms","ur","ps","be","zh-cn","vi","hy","nqo","sco","hr","sq","ml","smn","zh-hk","oc","te","az","se","th","tg","ga","nds","ka","bg","sr-el","ig","szl","or","scn","ta","ckb","is","lt","mr","kn","fy","ilo","et","gu","lb","sk","sh","my","pa","min","hsb","sc","os","ku-latn","tok","io","syl","hi","tg-cyrl","zh-mo","zh-sg","zh-my","yi","ks","ce","en-ca","arz","la","af","jv","tt-latn","xmf","yue","mg","ne","gsw","tl","kk","kaa","ksh","sd","diq","yo","pap","ia","bar","frr","uz","ky","an","mt","kw","sw","fo","nds-nl","gd","mzn","si","de-at","de-ch","co","pam","pcm","pcd","rm","ts"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"string"}
+  Schema 1:
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+...(570 lines omitted)...
+    "uk",
+    "et",
+    "ta",
+    "vi"
+  ]
+}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":["null","object"],"properties":{"zh-hk":{"type":"string"},"ast":{"type":"string"},"es":{"type":"string"},"nb":{"type":"string"},"zh-hant":{"type":"string"},"en":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"fr":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"pt":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"be":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"et":{"type":"string"},"ta":{"type":"string"},"vi":{"type":"string"},"sk":{"type":["null","string"]},"gn":{"type":["null","string"]},"li":{"type":["null","string"]},"is":{"type":["null","string"]},"min":{"type":["null","string"]},"zh-tw":{"type":["null","string"]},"sr-ec":{"type":["null","string"]},"oc":{"type":["null","string"]},"be-tarask":{"type":["null","string"]},"az":{"type":["null","string"]},"yue":{"type":["null","string"]},"kab":{"type":["null","string"]},"it":{"type":["null","string"]},"ms":{"type":["null","string"]},"yi":{"type":["null","string"]},"wuu":{"type":["null","string"]},"pt-br":{"type":["null","string"]},"lt":{"type":["null","string"]},"om":{"type":["null","string"]},"war":{"type":["null","string"]},"nds":{"type":["null","string"]},"ko":{"type":["null","string"]},"ku":{"type":["null","string"]},"sco":{"type":["null","string"]},"bs":{"type":["null","string"]},"hi":{"type":["null","string"]},"ro":{"type":["null","string"]},"gl":{"type":["null","string"]},"jam":{"type":["null","string"]},"tt":{"type":["null","string"]},"hr":{"type":["null","string"]},"ca":{"type":["null","string"]},"si":{"type":["null","string"]},"wa":{"type":["null","string"]},"as":{"type":["null","string"]},"mk":{"type":["null","string"]},"cs":{"type":["null","string"]},"ur":{"type":["null","string"]},"se":{"type":["null","string"]},"fi":{"type":["null","string"]},"arz":{"type":["null","string"]},"nl":{"type":["null","string"]},"la":{"type":["null","string"]},"ar":{"type":["null","string"]},"he":{"type":["null","string"]},"io":{"type":["null","string"]},"cy":{"type":["null","string"]},"tyv":{"type":["null","string"]},"sl":{"type":["null","string"]},"eu":{"type":["null","string"]},"nn":{"type":["null","string"]},"af":{"type":["null","string"]},"bcl":{"type":["null","string"]},"sr":{"type":["null","string"]},"ml":{"type":["null","string"]},"azb":{"type":["null","string"]},"mn":{"type":["null","string"]},"kk":{"type":["null","string"]},"bn":{"type":["null","string"]},"pl":{"type":["null","string"]},"lv":{"type":["null","string"]},"hy":{"type":["null","string"]},"sv":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"tr":{"type":["null","string"]},"ps":{"type":["null","string"]},"id":{"type":["null","string"]},"ga":{"type":["null","string"]},"eo":{"type":["null","string"]},"nan":{"type":["null","string"]},"el":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"tg":{"type":["null","string"]},"de":{"type":["null","string"]},"ary":{"type":["null","string"]},"zh-cn":{"type":["null","string"]},"fa":{"type":["null","string"]},"uz":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"sh":{"type":["null","string"]},"da":{"type":["null","string"]}},"required":["zh-hk","ast","es","nb","zh-hant","en","hu","ja","fr","zh","zh-hans","pt","th","bg","be","ru","uk","et","ta","vi"]}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 102 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "root" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 220 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"string"}
+  Schema 1: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+property-labels: All schemas are scalars, attempting scalar unification
+property-labels: Unified scalar schemas to nullable string
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": [
+    "null",
+    "string"
+  ]
+}
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "type": "array",
+  "items": {
+    "properties": {
+      "property": {
+        "type": "string"
+...(718 lines omitted)...
+      "property",
+      "property-labels"
+    ],
+    "type": "object"
+  }
+}
+  Schema 1:
+{
+  "type": "array",
+  "items": {
+    "properties": {
+      "property": {
+        "type": "string"
+...(630 lines omitted)...
+      "property",
+      "property-labels"
+    ],
+    "type": "object"
+  }
+}
+Schemas not homogeneous, attempting unification
+Field `datavalue` has conflicting object schemas, attempting recursive unify
+Schemas unified successfully
+Field `datavalue` unified successfully after recursion
+Field `property-labels` has conflicting object schemas, attempting recursive unify
+Schemas unified successfully
+Field `property-labels` unified successfully after recursion
+Schemas unified successfully
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "root" to map with schema:
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "property": {
+...(978 lines omitted)...
+      "datavalue",
+      "datatype",
+      "property-labels"
+    ]
+  }
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "qualifiers" with 1 schemas
+Unique normalised schemas (1 total):
+  Schema 0:
+{
+  "type": "array",
+  "items": {
+    "properties": {
+      "property": {
+        "type": "string"
+...(1090 lines omitted)...
+      "property",
+      "property-labels"
+    ],
+    "type": "object"
+  }
+}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "qualifiers" to map with schema:
+{
+  "type": "array",
+  "items": {
+    "properties": {
+      "property": {
+        "type": "string"
+...(1090 lines omitted)...
+      "property",
+      "property-labels"
+    ],
+    "type": "object"
+  }
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(463 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(595 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "mni": {
+      "type": "string"
+    },
+    "be-tarask": {
+...(451 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"mni":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"si":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"bs":{"type":"string"},"krj":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"pam":{"type":"string"},"ia":{"type":"string"},"af":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"hy":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"lv":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"gv":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"ceb":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"}},"required":["ady","af","an","ar","ary","arz","ast","az","azb","be","be-tarask","bg","bn","br","bs","ca","ceb","ckb","co","cs","cy","da","de","diq","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fy","ga","gd","gl","gv","ha","he","hr","hu","hy","hyw","ia","id","is","it","ja","ka","ko","krj","ks","ku","ky","la","lb","lt","lv","mk","ml","mn","mni","ms","mt","nan","nb","nl","nn","nqo","oc","pa","pam","pl","pnb","ps","pt","pt-br","ro","ru","sah","sc","scn","sco","si","sk","sl","sq","sr","sv","ta","th","tl","tok","tr","tt","uk","ur","vec","vi","wuu","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 114 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 150 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}

--- a/genson-cli/err3.txt
+++ b/genson-cli/err3.txt
@@ -696,6 +696,134 @@ Schemas not homogeneous, attempting unification
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -2251,6 +2379,134 @@ Schemas not homogeneous, attempting unification
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(145 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(541 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"nl":{"type":"string"},"de":{"type":"string"},"it":{"type":"string"},"ca":{"type":"string"},"gl":{"type":"string"},"uk":{"type":"string"},"be-tarask":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"tt-cyrl":{"type":"string"},"tt":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"da":{"type":"string"},"bn":{"type":"string"},"ms-arab":{"type":"string"},"cs":{"type":"string"},"nb":{"type":"string"},"ko":{"type":"string"},"en":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"ga":{"type":"string"},"sl":{"type":"string"},"sr-ec":{"type":"string"}},"required":["be-tarask","bn","ca","cs","da","de","en","es","fr","ga","gl","it","ja","ko","ms-arab","nb","nl","pt","sl","sr","sr-ec","sv","tt","tt-cyrl","uk"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"pfl":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"yi":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"arz":{"type":["null","string"]},"br":{"type":["null","string"]},"oc":{"type":["null","string"]},"mg":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"ps":{"type":["null","string"]},"de-ch":{"type":["null","string"]},"diq":{"type":["null","string"]},"olo":{"type":["null","string"]},"ig":{"type":["null","string"]},"ta":{"type":["null","string"]},"ky":{"type":["null","string"]},"yue":{"type":["null","string"]},"an":{"type":["null","string"]},"ht":{"type":["null","string"]},"lez":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","pnb","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","sq","hr","en-ca","nl","af","he","nn","ar","la","ia","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","is","da","pt-br","zh-hk","zh-tw","ast","az","te","es","ms","sms","lt","en-gb","vec","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","se","fi","cy","hu","ja","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ga","ru","pfl","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "nl": {
+      "type": "string"
+    },
+    "de": {
+...(95 lines omitted)...
+    "tt",
+    "tt-cyrl",
+    "uk"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"nl":{"type":"string"},"de":{"type":"string"},"it":{"type":"string"},"ca":{"type":"string"},"gl":{"type":"string"},"uk":{"type":"string"},"be-tarask":{"type":"string"},"ja":{"type":"string"},"sr":{"type":"string"},"tt-cyrl":{"type":"string"},"tt":{"type":"string"},"pt":{"type":"string"},"sv":{"type":"string"},"da":{"type":"string"},"bn":{"type":"string"},"ms-arab":{"type":"string"},"cs":{"type":"string"},"nb":{"type":"string"},"ko":{"type":"string"},"en":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"ga":{"type":"string"},"sl":{"type":"string"},"sr-ec":{"type":"string"}},"required":["be-tarask","bn","ca","cs","da","de","en","es","fr","ga","gl","it","ja","ko","ms-arab","nb","nl","pt","sl","sr","sr-ec","sv","tt","tt-cyrl","uk"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 25 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 127 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -3143,6 +3399,91 @@ Schemas not homogeneous, attempting unification
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"properties":{"en":{"type":"string"},"sv":{"type":"string"},"tt":{"type":"string"}},"required":["en","sv","tt"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(463 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"en":{"type":"string"},"sv":{"type":"string"},"tt":{"type":"string"}},"required":["en","sv","tt"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"pfl":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","arz","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ce","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","gu","he","hi","hr","hsb","hu","hy","ia","id","ilo","is","it","ja","ka","kaa","kk","ko","ks","la","lb","lt","lv","mg","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nl","nn","oc","or","pa","pfl","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","se","sh","sk","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","te","tg","tg-cyrl","th","tl","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"properties":{"en":{"type":"string"},"sv":{"type":"string"},"tt":{"type":"string"}},"required":["en","sv","tt"],"type":"object"}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"en":{"type":"string"},"sv":{"type":"string"},"tt":{"type":"string"}},"required":["en","sv","tt"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 3 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 117 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -3642,6 +3983,115 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": [
+      "null",
+      {
+...(151 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(648 lines omitted)...
+    "ig",
+    "ta",
+    "ky",
+    "yue"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":["null",{"type":["null","string"]}],"labels":["null",{"properties":{"en":{"type":"string"},"ca":{"type":"string"},"nl":{"type":"string"},"de":{"type":"string"},"uk":{"type":"string"},"ar":{"type":"string"},"be-tarask":{"type":"string"},"ja":{"type":"string"},"bn":{"type":"string"},"en-gb":{"type":"string"},"nb":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"pt":{"type":"string"},"eu":{"type":"string"},"it":{"type":"string"},"vi":{"type":"string"},"sl":{"type":"string"},"ga":{"type":"string"}},"required":["ar","be-tarask","bn","ca","de","en","en-gb","es","eu","fr","ga","it","ja","nb","nl","pt","sl","uk","vi"],"type":["null","object"]}],"time":["null",{"type":["null","string"]}],"timezone":["null",{"type":["null","integer"]}],"before":["null",{"type":["null","integer"]}],"after":["null",{"type":["null","integer"]}],"precision":["null",{"type":["null","integer"]}],"calendarmodel":["null",{"type":["null","string"]}],"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"br":{"type":["null","string"]},"oc":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"ps":{"type":["null","string"]},"de-ch":{"type":["null","string"]},"ig":{"type":["null","string"]},"ta":{"type":["null","string"]},"ky":{"type":["null","string"]},"yue":{"type":["null","string"]},"la":{"type":["null","string"]},"pfl":{"type":["null","string"]},"mzn":{"type":["null","string"]},"yi":["null",{"type":["null","string"]}],"arz":["null",{"type":["null","string"]}],"mg":["null",{"type":["null","string"]}],"diq":["null",{"type":["null","string"]}],"olo":["null",{"type":["null","string"]}],"an":["null",{"type":["null","string"]}],"ht":["null",{"type":["null","string"]}],"lez":["null",{"type":["null","string"]}],"de-at":{"type":["null","string"]},"ha":{"type":["null","string"]},"bho":{"type":["null","string"]},"sc":{"type":["null","string"]},"kl":{"type":["null","string"]},"ku":{"type":["null","string"]},"gpe":{"type":["null","string"]},"en-us":{"type":["null","string"]},"io":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","pnb","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","sq","hr","en-ca","nl","af","he","nn","ar","ia","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","is","da","pt-br","zh-hk","zh-tw","ast","az","te","es","ms","sms","lt","en-gb","vec","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","se","fi","cy","hu","ja","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ga","ru","et","gu","vi","tg","de","lb","fa","sk","sh","ks","ce","br","oc","zh-my","ps","de-ch","ig","ta","ky","yue"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): ["null",{"properties":{"en":{"type":"string"},"ca":{"type":"string"},"nl":{"type":"string"},"de":{"type":"string"},"uk":{"type":"string"},"ar":{"type":"string"},"be-tarask":{"type":"string"},"ja":{"type":"string"},"bn":{"type":"string"},"en-gb":{"type":"string"},"nb":{"type":"string"},"fr":{"type":"string"},"es":{"type":"string"},"pt":{"type":"string"},"eu":{"type":"string"},"it":{"type":"string"},"vi":{"type":"string"},"sl":{"type":"string"},"ga":{"type":"string"}},"required":["ar","be-tarask","bn","ca","de","en","en-gb","es","eu","fr","ga","it","ja","nb","nl","pt","sl","uk","vi"],"type":["null","object"]}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 19 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "root" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 138 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"string"}
+  Schema 1: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+property-labels: All schemas are scalars, attempting scalar unification
+property-labels: Unified scalar schemas to nullable string
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": [
+    "null",
+    "string"
+  ]
+}
+Checking homogeneity for field "root" with 9 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": [
+      "null",
+      {
+...(71 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":["null",{"type":["null","string"]}],"labels":["null",{"type":"object","additionalProperties":{"type":"string"}}],"time":["null",{"type":["null","string"]}],"timezone":["null",{"type":["null","integer"]}],"before":["null",{"type":["null","integer"]}],"after":["null",{"type":["null","integer"]}],"precision":["null",{"type":["null","integer"]}],"calendarmodel":["null",{"type":["null","string"]}],"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 9 schemas
+Found 4 unique normalised schemas (too many to display)
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): ["null",{"type":"object","additionalProperties":{"type":"string"}}]
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -4569,6 +5019,117 @@ Schemas not homogeneous, attempting unification
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(511 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(527 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"bs":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"jv":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"fi":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","ary","arz","as","ast","az","ba","be","be-tarask","bg","bho","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","inh","io","is","it","ja","jv","ka","kaa","kk","kn","ko","ks","ksh","la","lb","lt","lv","mg","min","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","sh","sk","sl","sq","sr","sr-ec","sr-el","sv","ta","tcy","te","tg","tg-cyrl","th","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "mni": {
+...(499 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 126 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 133 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
   Schema 0: {"properties":{"amount":{"type":"string"},"unit":{"type":"string"},"unit-labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["amount","unit","unit-labels"],"type":"object"}
   Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 2: {"type":"string"}
@@ -5095,6 +5656,45 @@ Converting field "qualifiers" to map with schema:
 }
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(347 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"tt-cyrl":{"type":"string"},"uz":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"be-tarask":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"nds":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ro":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"hr":{"type":"string"},"en":{"type":"string"},"hi":{"type":"string"},"gsw":{"type":"string"},"bs":{"type":"string"},"cs":{"type":"string"},"tt":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"ar":{"type":"string"},"cy":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"smn":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"kaa":{"type":"string"},"be":{"type":"string"},"id":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"ga":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"dag":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"ba":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"ku-latn":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"sk":{"type":"string"},"frr":{"type":"string"},"da":{"type":"string"}},"required":["af","ar","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","he","hi","hr","hsb","hu","id","it","ja","ka","kaa","ko","ku-latn","lb","lt","lv","mk","ms","ms-arab","my","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","se","sk","sl","smn","sms","sq","sr","sv","sw","tg","th","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 88 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
 Schemas not homogeneous, attempting unification
@@ -5520,6 +6120,117 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "text": [
+      "null",
+      {
+...(56 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(940 lines omitted)...
+    "an",
+    "ht",
+    "pfl",
+    "mzn"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"text":["null",{"type":["null","string"]}],"language":["null",{"type":["null","string"]}],"datavalue__string":["null",{"type":["null","string"]}],"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"zh-hant":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"be":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"frr":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"de-ch":{"type":["null","string"]},"sco":{"type":["null","string"]},"ia":{"type":["null","string"]},"smn":{"type":["null","string"]},"sms":{"type":["null","string"]},"se":{"type":["null","string"]},"diq":{"type":["null","string"]},"la":{"type":["null","string"]},"olo":{"type":["null","string"]},"an":{"type":["null","string"]},"ht":{"type":["null","string"]},"pfl":{"type":["null","string"]},"mzn":{"type":["null","string"]},"ha":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"br":{"type":["null","string"]},"oc":{"type":["null","string"]},"io":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"fo":{"type":["null","string"]},"ps":{"type":["null","string"]},"de-at":["null",{"type":["null","string"]}],"bho":["null",{"type":["null","string"]}],"sc":["null",{"type":["null","string"]}],"kl":["null",{"type":["null","string"]}],"ku":["null",{"type":["null","string"]}],"gpe":["null",{"type":["null","string"]}],"en-us":["null",{"type":["null","string"]}],"sw":["null",{"type":["null","string"]}],"km":["null",{"type":["null","string"]}],"om":["null",{"type":["null","string"]}],"haw":["null",{"type":["null","string"]}],"yi":["null",{"type":["null","string"]}],"ban-bali":["null",{"type":["null","string"]}],"si":["null",{"type":["null","string"]}],"as":["null",{"type":["null","string"]}],"yo":["null",{"type":["null","string"]}],"ban":["null",{"type":["null","string"]}],"pap":["null",{"type":["null","string"]}],"ext":["null",{"type":["null","string"]}],"nod":["null",{"type":["null","string"]}],"mn":["null",{"type":["null","string"]}],"pcm":["null",{"type":["null","string"]}],"myv":["null",{"type":["null","string"]}],"lo":["null",{"type":["null","string"]}],"no":["null",{"type":["null","string"]}],"shi":["null",{"type":["null","string"]}],"szl":["null",{"type":["null","string"]}],"ku-latn":["null",{"type":["null","string"]}],"ckb":["null",{"type":["null","string"]}],"ne":["null",{"type":["null","string"]}],"wa":["null",{"type":["null","string"]}],"grc":["null",{"type":["null","string"]}],"kw":["null",{"type":["null","string"]}],"udm":["null",{"type":["null","string"]}],"lfn":["null",{"type":["null","string"]}],"kn":["null",{"type":["null","string"]}],"fy":["null",{"type":["null","string"]}],"gd":["null",{"type":["null","string"]}],"crh":["null",{"type":["null","string"]}],"zu":["null",{"type":["null","string"]}],"pap-aw":["null",{"type":["null","string"]}],"kab":["null",{"type":["null","string"]}],"lez":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","pnb","nds","zh-mo","ro","bs","gl","ka","tt","zh-hant","sq","hr","en-ca","nl","af","nn","he","ar","sl","eu","my","ml","pl","hy","lv","pa","pt","ig","sv","sr-el","be","bg","tr","ba","dag","eo","uk","el","zh-sg","scn","or","ta","zh-cn","xmf","uz","ky","is","da","pt-br","frr","zh-hk","zh-tw","ast","yue","az","te","es","ms","lt","en-gb","vec","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","th","nap","ga","ru","et","gu","vi","tg","de","lb","fa","sk","sh","de-ch","sco","ia","smn","sms","se","diq","la","olo","an","ht","pfl","mzn"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 169 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"string"}
+  Schema 1: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+property-labels: All schemas are scalars, attempting scalar unification
+property-labels: Unified scalar schemas to nullable string
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": [
+    "null",
+    "string"
+  ]
+}
+Checking homogeneity for field "root" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "text": [
+      "null",
+      {
+...(56 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"text":["null",{"type":["null","string"]}],"language":["null",{"type":["null","string"]}],"datavalue__string":["null",{"type":["null","string"]}],"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -6395,6 +7106,117 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "text": [
+      "null",
+      {
+...(56 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(940 lines omitted)...
+    "an",
+    "ht",
+    "pfl",
+    "mzn"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"text":["null",{"type":["null","string"]}],"language":["null",{"type":["null","string"]}],"datavalue__string":["null",{"type":["null","string"]}],"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"zh-hant":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"be":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"frr":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"de-ch":{"type":["null","string"]},"sco":{"type":["null","string"]},"ia":{"type":["null","string"]},"smn":{"type":["null","string"]},"sms":{"type":["null","string"]},"se":{"type":["null","string"]},"diq":{"type":["null","string"]},"la":{"type":["null","string"]},"olo":{"type":["null","string"]},"an":{"type":["null","string"]},"ht":{"type":["null","string"]},"pfl":{"type":["null","string"]},"mzn":{"type":["null","string"]},"ha":{"type":["null","string"]},"ks":{"type":["null","string"]},"ce":{"type":["null","string"]},"br":{"type":["null","string"]},"oc":{"type":["null","string"]},"io":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"fo":{"type":["null","string"]},"ps":{"type":["null","string"]},"de-at":["null",{"type":["null","string"]}],"bho":["null",{"type":["null","string"]}],"sc":["null",{"type":["null","string"]}],"kl":["null",{"type":["null","string"]}],"ku":["null",{"type":["null","string"]}],"gpe":["null",{"type":["null","string"]}],"en-us":["null",{"type":["null","string"]}],"sw":["null",{"type":["null","string"]}],"km":["null",{"type":["null","string"]}],"om":["null",{"type":["null","string"]}],"haw":["null",{"type":["null","string"]}],"yi":["null",{"type":["null","string"]}],"ban-bali":["null",{"type":["null","string"]}],"si":["null",{"type":["null","string"]}],"as":["null",{"type":["null","string"]}],"yo":["null",{"type":["null","string"]}],"ban":["null",{"type":["null","string"]}],"pap":["null",{"type":["null","string"]}],"ext":["null",{"type":["null","string"]}],"nod":["null",{"type":["null","string"]}],"mn":["null",{"type":["null","string"]}],"pcm":["null",{"type":["null","string"]}],"myv":["null",{"type":["null","string"]}],"lo":["null",{"type":["null","string"]}],"no":["null",{"type":["null","string"]}],"shi":["null",{"type":["null","string"]}],"szl":["null",{"type":["null","string"]}],"ku-latn":["null",{"type":["null","string"]}],"ckb":["null",{"type":["null","string"]}],"ne":["null",{"type":["null","string"]}],"wa":["null",{"type":["null","string"]}],"grc":["null",{"type":["null","string"]}],"kw":["null",{"type":["null","string"]}],"udm":["null",{"type":["null","string"]}],"lfn":["null",{"type":["null","string"]}],"kn":["null",{"type":["null","string"]}],"fy":["null",{"type":["null","string"]}],"gd":["null",{"type":["null","string"]}],"crh":["null",{"type":["null","string"]}],"zu":["null",{"type":["null","string"]}],"pap-aw":["null",{"type":["null","string"]}],"kab":["null",{"type":["null","string"]}],"lez":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","nb","pnb","nds","zh-mo","ro","bs","gl","ka","tt","zh-hant","sq","hr","en-ca","nl","af","nn","he","ar","sl","eu","my","ml","pl","hy","lv","pa","pt","ig","sv","sr-el","be","bg","tr","ba","dag","eo","uk","el","zh-sg","scn","or","ta","zh-cn","xmf","uz","ky","is","da","pt-br","frr","zh-hk","zh-tw","ast","yue","az","te","es","ms","lt","en-gb","vec","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","th","nap","ga","ru","et","gu","vi","tg","de","lb","fa","sk","sh","de-ch","sco","ia","smn","sms","se","diq","la","olo","an","ht","pfl","mzn"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 169 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"string"}
+  Schema 1: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+property-labels: All schemas are scalars, attempting scalar unification
+property-labels: Unified scalar schemas to nullable string
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": [
+    "null",
+    "string"
+  ]
+}
+Checking homogeneity for field "root" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":["null","string"]}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "text": [
+      "null",
+      {
+...(56 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"text":["null",{"type":["null","string"]}],"language":["null",{"type":["null","string"]}],"datavalue__string":["null",{"type":["null","string"]}],"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":["null","string"]}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+datavalue: All schemas are scalars, attempting scalar unification
+datavalue: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 9 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"string"}
+  Schema 2: {"type":["null","string"]}
+Schemas not homogeneous, attempting unification
+: All schemas are scalars, attempting scalar unification
+: Cannot unify incompatible scalar types: ["integer", "string"]
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:

--- a/genson-cli/err4.txt
+++ b/genson-cli/err4.txt
@@ -924,6 +924,117 @@ Schemas not homogeneous, attempting unification
   Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(391 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(463 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"pt-br":{"type":"string"},"sh":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"sr-ec":{"type":"string"},"oc":{"type":"string"},"be-tarask":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"ha":{"type":"string"},"nb":{"type":"string"},"sms":{"type":"string"},"fit":{"type":"string"},"sjd":{"type":"string"},"sju":{"type":"string"},"en-gb":{"type":"string"},"de-ch":{"type":"string"},"zh-mo":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mt":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"hr":{"type":"string"},"en":{"type":"string"},"si":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"fi":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"se":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"zh-my":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"gd":{"type":"string"},"hy":{"type":"string"},"id":{"type":"string"},"tr":{"type":"string"},"sv":{"type":"string"},"bg":{"type":"string"},"th":{"type":"string"},"be":{"type":"string"},"ga":{"type":"string"},"eo":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"nan":{"type":"string"},"sje":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"vi":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"zh-cn":{"type":"string"},"fa":{"type":"string"},"kl":{"type":"string"},"frr":{"type":"string"},"sk":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"}},"required":["af","ar","arz","ast","az","be","be-tarask","bg","bho","bn","bs","ca","cs","da","de","de-ch","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fit","fo","fr","frr","ga","gd","gl","ha","he","hi","hr","hu","hy","id","ilo","is","it","ja","ka","kl","ko","lv","mhr","mk","ms","mt","nan","nb","nl","nn","oc","or","pl","pt","pt-br","rmf","ro","ru","scn","se","sh","si","sjd","sje","sju","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sv","th","tr","uk","ur","vi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"pfl":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","arz","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ce","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","gu","he","hi","hr","hsb","hu","hy","ia","id","ilo","is","it","ja","ka","kaa","kk","ko","ks","la","lb","lt","lv","mg","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nl","nn","oc","or","pa","pfl","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","se","sh","sk","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","te","tg","tg-cyrl","th","tl","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sh": {
+...(379 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sh":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"sr-ec":{"type":"string"},"oc":{"type":"string"},"be-tarask":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"ha":{"type":"string"},"nb":{"type":"string"},"sms":{"type":"string"},"fit":{"type":"string"},"sjd":{"type":"string"},"sju":{"type":"string"},"en-gb":{"type":"string"},"de-ch":{"type":"string"},"zh-mo":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mt":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"hr":{"type":"string"},"en":{"type":"string"},"si":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"fi":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"se":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"zh-my":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"gd":{"type":"string"},"hy":{"type":"string"},"id":{"type":"string"},"tr":{"type":"string"},"sv":{"type":"string"},"bg":{"type":"string"},"th":{"type":"string"},"be":{"type":"string"},"ga":{"type":"string"},"eo":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"nan":{"type":"string"},"sje":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"vi":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"zh-cn":{"type":"string"},"fa":{"type":"string"},"kl":{"type":"string"},"frr":{"type":"string"},"sk":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"}},"required":["af","ar","arz","ast","az","be","be-tarask","bg","bho","bn","bs","ca","cs","da","de","de-ch","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fit","fo","fr","frr","ga","gd","gl","ha","he","hi","hr","hu","hy","id","ilo","is","it","ja","ka","kl","ko","lv","mhr","mk","ms","mt","nan","nb","nl","nn","oc","or","pl","pt","pt-br","rmf","ro","ru","scn","se","sh","si","sjd","sje","sju","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sv","th","tr","uk","ur","vi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 96 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 117 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
@@ -1403,6 +1514,134 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(261 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(685 lines omitted)...
+    "fa",
+    "mzn",
+    "sk",
+    "sh"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"bs":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"tt":{"type":"string"},"ce":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"en-ca":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"ba":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"ga":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"is":{"type":["null","string"]},"se":{"type":["null","string"]},"pfl":{"type":["null","string"]},"km":{"type":["null","string"]},"kcg":{"type":["null","string"]},"ha":{"type":["null","string"]},"diq":{"type":["null","string"]},"as":{"type":["null","string"]},"yo":{"type":["null","string"]},"ban":{"type":["null","string"]},"pap":{"type":["null","string"]},"sah":{"type":["null","string"]},"ig":{"type":["null","string"]},"lo":{"type":["null","string"]},"no":{"type":["null","string"]},"shi":{"type":["null","string"]},"ta":{"type":["null","string"]},"ku-latn":{"type":["null","string"]},"ckb":{"type":["null","string"]},"ky":{"type":["null","string"]},"nqo":{"type":["null","string"]},"skr":{"type":["null","string"]},"yue":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"mt":{"type":["null","string"]},"kw":{"type":["null","string"]},"gpe":{"type":["null","string"]},"rue":{"type":["null","string"]},"sw":{"type":["null","string"]},"fo":{"type":["null","string"]},"kn":{"type":["null","string"]},"fy":{"type":["null","string"]},"gd":{"type":["null","string"]},"crh":{"type":["null","string"]},"zu":{"type":["null","string"]},"mi":{"type":["null","string"]},"dsb":{"type":["null","string"]}},"required":["tt-cyrl","sr-ec","be-tarask","it","yi","nb","pnb","ks","zh-mo","nds","sco","zh-hant","ro","bs","ka","gl","tt","ce","sq","hr","en-ca","nl","af","he","nn","ar","sl","eu","my","ml","smn","pl","hy","lv","pa","pt","be","sv","sr-el","bg","ba","tr","dag","br","eo","uk","el","zh-sg","scn","or","zh-cn","frr","xmf","uz","da","pt-br","zh-hk","zh-tw","ast","oc","az","te","es","ms","sms","lt","en-gb","vec","mg","ko","mr","mk","hi","hsb","ms-arab","ca","gsw","en","cs","ur","tl","fi","cy","hu","ja","zh-my","tg-cyrl","sr","fr","kk","bn","ilo","zh","zh-hans","kaa","id","nap","th","ps","ga","ru","et","gu","vi","tg","de","lb","fa","mzn","sk","sh"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "sl": {
+...(211 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"integer"}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"sl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"is":{"type":"string"},"tg-cyrl":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"ml":{"type":"string"},"fr":{"type":"string"},"be-tarask":{"type":"string"},"te":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"bn":{"type":"string"},"ms":{"type":"string"},"nb":{"type":"string"},"pl":{"type":"string"},"en-gb":{"type":"string"},"lv":{"type":"string"},"nds":{"type":"string"},"pt":{"type":"string"},"ko":{"type":"string"},"zh-hans":{"type":"string"},"zh":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"sco":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"id":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ms-arab":{"type":"string"},"ru":{"type":"string"},"ca":{"type":"string"},"uk":{"type":"string"},"en":{"type":"string"},"hy":{"type":"string"},"el":{"type":"string"},"cs":{"type":"string"},"scn":{"type":"string"},"ur":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"nl":{"type":"string"},"fa":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"sk":{"type":"string"},"nn":{"type":"string"},"da":{"type":"string"}},"required":["ar","ast","be","be-tarask","bn","ca","cs","da","de","el","en","en-gb","es","fa","fr","gl","he","hi","hu","hy","id","is","it","ja","ko","lv","mk","ml","ms","ms-arab","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","scn","sco","sk","sl","sv","te","tg","tg-cyrl","uk","ur","vi","zh","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 54 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 152 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(41 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"time":{"type":["null","string"]},"timezone":{"type":["null","integer"]},"before":{"type":["null","integer"]},"after":{"type":["null","integer"]},"precision":{"type":["null","integer"]},"calendarmodel":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 8 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"integer"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -2172,6 +2411,45 @@ Converting field "qualifiers" to map with schema:
 }
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "pt-br": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(347 lines omitted)...
+    "zh-hant",
+    "zh-hk",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"properties":{"pt-br":{"type":"string"},"tt-cyrl":{"type":"string"},"uz":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"be-tarask":{"type":"string"},"az":{"type":"string"},"it":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"nds":{"type":"string"},"ko":{"type":"string"},"mk":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ro":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"sq":{"type":"string"},"ca":{"type":"string"},"hr":{"type":"string"},"en":{"type":"string"},"hi":{"type":"string"},"gsw":{"type":"string"},"bs":{"type":"string"},"cs":{"type":"string"},"tt":{"type":"string"},"ur":{"type":"string"},"en-ca":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"ar":{"type":"string"},"cy":{"type":"string"},"he":{"type":"string"},"nn":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sw":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"smn":{"type":"string"},"bn":{"type":"string"},"pl":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"kaa":{"type":"string"},"be":{"type":"string"},"id":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"th":{"type":"string"},"bg":{"type":"string"},"ga":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"dag":{"type":"string"},"ru":{"type":"string"},"uk":{"type":"string"},"ba":{"type":"string"},"el":{"type":"string"},"et":{"type":"string"},"ku-latn":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"sk":{"type":"string"},"frr":{"type":"string"},"da":{"type":"string"}},"required":["af","ar","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","ga","gl","gsw","he","hi","hr","hsb","hu","id","it","ja","ka","kaa","ko","ku-latn","lb","lt","lv","mk","ms","ms-arab","my","nb","nds","nl","nn","pl","pt","pt-br","ro","ru","se","sk","sl","smn","sms","sq","sr","sv","sw","tg","th","tr","tt","tt-cyrl","uk","ur","uz","vec","vi","xmf","yi","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 88 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 1: {"type":"string"}
 Schemas not homogeneous, attempting unification
@@ -2388,6 +2666,117 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(1371 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(595 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"dz":{"type":"string"},"tt-cyrl":{"type":"string"},"gcr":{"type":"string"},"rup":{"type":"string"},"nia":{"type":"string"},"pi":{"type":"string"},"ff":{"type":"string"},"be-tarask":{"type":"string"},"de-at":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ks":{"type":"string"},"ie":{"type":"string"},"ryu":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"ng":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ve":{"type":"string"},"tcy":{"type":"string"},"si":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"guw":{"type":"string"},"bxr":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"pam":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"ik":{"type":"string"},"azb":{"type":"string"},"os":{"type":"string"},"ml":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"mn":{"type":"string"},"olo":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"tt-latn":{"type":"string"},"ami":{"type":"string"},"sat":{"type":"string"},"pcm":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"wo":{"type":"string"},"ny":{"type":"string"},"tr":{"type":"string"},"ab":{"type":"string"},"eo":{"type":"string"},"br":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"kl":{"type":"string"},"is":{"type":"string"},"gn":{"type":"string"},"min":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"hyw":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"nv":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"nqo":{"type":"string"},"skr":{"type":"string"},"az":{"type":"string"},"nrm":{"type":"string"},"te":{"type":"string"},"guc":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"tw":{"type":"string"},"bm":{"type":"string"},"awa":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"got":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ku":{"type":"string"},"ko":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"jam":{"type":"string"},"gan":{"type":"string"},"xh":{"type":"string"},"btm":{"type":"string"},"lbe":{"type":"string"},"grc":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"mnw":{"type":"string"},"fj":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"udm":{"type":"string"},"tyv":{"type":"string"},"csb":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"jbo":{"type":"string"},"fr":{"type":"string"},"glk":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"arq":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"kr":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"krc":{"type":"string"},"tum":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"kg":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"sg":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"chr":{"type":"string"},"sh":{"type":"string"},"rw":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"om":{"type":"string"},"pih":{"type":"string"},"kcg":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"kbd":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"de-ch":{"type":"string"},"sd":{"type":"string"},"bi":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"hil":{"type":"string"},"bs":{"type":"string"},"blk":{"type":"string"},"sq":{"type":"string"},"lg":{"type":"string"},"mad":{"type":"string"},"yo":{"type":"string"},"mwl":{"type":"string"},"fur":{"type":"string"},"ee":{"type":"string"},"map-bms":{"type":"string"},"shn":{"type":"string"},"bho":{"type":"string"},"co":{"type":"string"},"arz":{"type":"string"},"ban":{"type":"string"},"ace":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"cbk-zam":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"za":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"bpy":{"type":"string"},"pag":{"type":"string"},"iu":{"type":"string"},"cr":{"type":"string"},"tk":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"gom":{"type":"string"},"bg":{"type":"string"},"dag":{"type":"string"},"shi":{"type":"string"},"lo":{"type":"string"},"myv":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"trv":{"type":"string"},"cu":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"gag":{"type":"string"},"da":{"type":"string"},"bo":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"mrj":{"type":"string"},"lmo":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"tpi":{"type":"string"},"dtp":{"type":"string"},"mg":{"type":"string"},"mai":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"gsw":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"bcl":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"rue":{"type":"string"},"lfn":{"type":"string"},"arc":{"type":"string"},"ss":{"type":"string"},"ja":{"type":"string"},"bug":{"type":"string"},"sr":{"type":"string"},"av":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"ty":{"type":"string"},"kn":{"type":"string"},"xal":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"brh":{"type":"string"},"tly":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"lez":{"type":"string"},"am":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"tok":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"bew":{"type":"string"},"roa-tara":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"ts":{"type":"string"},"de":{"type":"string"},"lad":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"bjn":{"type":"string"},"lij":{"type":"string"},"ltg":{"type":"string"},"kab":{"type":"string"},"ay":{"type":"string"}},"required":["ab","ace","ady","aeb-arab","af","am","ami","an","ang","anp","ar","arc","arq","ary","arz","as","ast","av","awa","ay","az","azb","ba","ban","bar","bbc","bcl","be","be-tarask","bew","bg","bho","bi","bjn","blk","bm","bn","bo","bpy","br","brh","bs","btm","bug","bxr","ca","cbk-zam","cdo","ce","ceb","chr","chy","ckb","co","cr","crh","crh-latn","cs","csb","cu","cv","cy","da","dag","de","de-at","de-ch","diq","dsb","dtp","dty","dv","dz","ee","el","eml","en","en-gb","en-us","eo","es","et","eu","ext","fa","ff","fi","fj","fo","fr","frp","frr","fur","fy","ga","gag","gan","gcr","gd","gl","glk","gn","gom","got","gpe","grc","gsw","gu","guc","guw","gv","ha","hak","haw","he","hi","hif","hil","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ig","ik","ilo","inh","io","is","it","iu","ja","jam","jbo","jv","ka","kaa","kab","kbd","kbp","kcg","kg","kk","kl","km","kn","ko","koi","kr","krc","ks","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lbe","lez","lfn","lg","li","lij","lld","lmo","ln","lo","lrc","lt","ltg","lv","lzh","mad","mai","map-bms","mdf","mg","mhr","mi","min","mk","ml","mn","mni","mnw","mr","mrj","ms","ms-arab","mt","mwl","my","myv","mzn","na","nah","nan","nap","nb","nds","nds-nl","ne","new","ng","nia","nl","nn","nov","nqo","nrm","nso","nv","ny","oc","olo","om","or","os","pa","pag","pam","pap","pcd","pcm","pdc","pfl","pi","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","rmf","ro","roa-tara","ru","rue","rup","rw","ryu","sa","sah","sat","sc","scn","sco","sd","se","sg","sgs","sh","shi","shn","si","sk","skr","sl","sm","smn","sms","sn","so","sq","sr","sr-ec","srn","ss","st","stq","su","sv","sw","syl","szl","ta","tcy","te","tg","tg-cyrl","th","ti","tk","tl","tly","tn","to","tok","tpi","tr","trv","ts","tt","tt-cyrl","tt-latn","tum","tw","ty","tyv","udm","ug","uk","ur","uz","ve","vec","vep","vi","vls","vo","vro","wa","war","wo","wuu","xal","xh","xmf","yi","yo","yue","za","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "dz": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(1359 lines omitted)...
+    "zh-hk",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"dz":{"type":"string"},"tt-cyrl":{"type":"string"},"gcr":{"type":"string"},"rup":{"type":"string"},"nia":{"type":"string"},"pi":{"type":"string"},"ff":{"type":"string"},"be-tarask":{"type":"string"},"de-at":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ks":{"type":"string"},"ie":{"type":"string"},"ryu":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"ng":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ve":{"type":"string"},"tcy":{"type":"string"},"si":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"guw":{"type":"string"},"bxr":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"pam":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"ik":{"type":"string"},"azb":{"type":"string"},"os":{"type":"string"},"ml":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"mn":{"type":"string"},"olo":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"tt-latn":{"type":"string"},"ami":{"type":"string"},"sat":{"type":"string"},"pcm":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"wo":{"type":"string"},"ny":{"type":"string"},"tr":{"type":"string"},"ab":{"type":"string"},"eo":{"type":"string"},"br":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"kl":{"type":"string"},"is":{"type":"string"},"gn":{"type":"string"},"min":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"hyw":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"nv":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"nqo":{"type":"string"},"skr":{"type":"string"},"az":{"type":"string"},"nrm":{"type":"string"},"te":{"type":"string"},"guc":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"tw":{"type":"string"},"bm":{"type":"string"},"awa":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"got":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ku":{"type":"string"},"ko":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"jam":{"type":"string"},"gan":{"type":"string"},"xh":{"type":"string"},"btm":{"type":"string"},"lbe":{"type":"string"},"grc":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"mnw":{"type":"string"},"fj":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"udm":{"type":"string"},"tyv":{"type":"string"},"csb":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"jbo":{"type":"string"},"fr":{"type":"string"},"glk":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"arq":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"kr":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"krc":{"type":"string"},"tum":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"kg":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"sg":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"chr":{"type":"string"},"sh":{"type":"string"},"rw":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"om":{"type":"string"},"pih":{"type":"string"},"kcg":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"kbd":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"de-ch":{"type":"string"},"sd":{"type":"string"},"bi":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"hil":{"type":"string"},"bs":{"type":"string"},"blk":{"type":"string"},"sq":{"type":"string"},"lg":{"type":"string"},"mad":{"type":"string"},"yo":{"type":"string"},"mwl":{"type":"string"},"fur":{"type":"string"},"ee":{"type":"string"},"map-bms":{"type":"string"},"shn":{"type":"string"},"bho":{"type":"string"},"co":{"type":"string"},"arz":{"type":"string"},"ban":{"type":"string"},"ace":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"cbk-zam":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"za":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"bpy":{"type":"string"},"pag":{"type":"string"},"iu":{"type":"string"},"cr":{"type":"string"},"tk":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"gom":{"type":"string"},"bg":{"type":"string"},"dag":{"type":"string"},"shi":{"type":"string"},"lo":{"type":"string"},"myv":{"type":"string"},"el":{"type":"string"},"ady":{"type":"string"},"trv":{"type":"string"},"cu":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"gag":{"type":"string"},"da":{"type":"string"},"bo":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"mrj":{"type":"string"},"lmo":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"tpi":{"type":"string"},"dtp":{"type":"string"},"mg":{"type":"string"},"mai":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"gsw":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"bcl":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"rue":{"type":"string"},"lfn":{"type":"string"},"arc":{"type":"string"},"ss":{"type":"string"},"ja":{"type":"string"},"bug":{"type":"string"},"sr":{"type":"string"},"av":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"ty":{"type":"string"},"kn":{"type":"string"},"xal":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"brh":{"type":"string"},"tly":{"type":"string"},"nap":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"lez":{"type":"string"},"am":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"tok":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"bew":{"type":"string"},"roa-tara":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"ts":{"type":"string"},"de":{"type":"string"},"lad":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"bjn":{"type":"string"},"lij":{"type":"string"},"ltg":{"type":"string"},"kab":{"type":"string"},"ay":{"type":"string"}},"required":["ab","ace","ady","aeb-arab","af","am","ami","an","ang","anp","ar","arc","arq","ary","arz","as","ast","av","awa","ay","az","azb","ba","ban","bar","bbc","bcl","be","be-tarask","bew","bg","bho","bi","bjn","blk","bm","bn","bo","bpy","br","brh","bs","btm","bug","bxr","ca","cbk-zam","cdo","ce","ceb","chr","chy","ckb","co","cr","crh","crh-latn","cs","csb","cu","cv","cy","da","dag","de","de-at","de-ch","diq","dsb","dtp","dty","dv","dz","ee","el","eml","en","en-gb","en-us","eo","es","et","eu","ext","fa","ff","fi","fj","fo","fr","frp","frr","fur","fy","ga","gag","gan","gcr","gd","gl","glk","gn","gom","got","gpe","grc","gsw","gu","guc","guw","gv","ha","hak","haw","he","hi","hif","hil","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ig","ik","ilo","inh","io","is","it","iu","ja","jam","jbo","jv","ka","kaa","kab","kbd","kbp","kcg","kg","kk","kl","km","kn","ko","koi","kr","krc","ks","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lbe","lez","lfn","lg","li","lij","lld","lmo","ln","lo","lrc","lt","ltg","lv","lzh","mad","mai","map-bms","mdf","mg","mhr","mi","min","mk","ml","mn","mni","mnw","mr","mrj","ms","ms-arab","mt","mwl","my","myv","mzn","na","nah","nan","nap","nb","nds","nds-nl","ne","new","ng","nia","nl","nn","nov","nqo","nrm","nso","nv","ny","oc","olo","om","or","os","pa","pag","pam","pap","pcd","pcm","pdc","pfl","pi","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","rmf","ro","roa-tara","ru","rue","rup","rw","ryu","sa","sah","sat","sc","scn","sco","sd","se","sg","sgs","sh","shi","shn","si","sk","skr","sl","sm","smn","sms","sn","so","sq","sr","sr-ec","srn","ss","st","stq","su","sv","sw","syl","szl","ta","tcy","te","tg","tg-cyrl","th","ti","tk","tl","tly","tn","to","tok","tpi","tr","trv","ts","tt","tt-cyrl","tt-latn","tum","tw","ty","tyv","udm","ug","uk","ur","uz","ve","vec","vep","vi","vls","vo","vro","wa","war","wo","wuu","xal","xh","xmf","yi","yo","yue","za","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 341 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 150 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
@@ -3421,6 +3810,45 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "chr": {
+      "type": "string"
+    },
+    "tt-cyrl": {
+...(619 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): {"properties":{"chr":{"type":"string"},"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"rgn":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"bs":{"type":"string"},"ro":{"type":"string"},"ka":{"type":"string"},"gl":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"diq":{"type":"string"},"yo":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"ext":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"pcm":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"vmf":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"szl":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"hyw":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"min":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"gn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ku":{"type":"string"},"ne":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"mt":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"csb":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"crh":{"type":"string"},"am":{"type":"string"},"ga":{"type":"string"},"cv":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"ts":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"ksh":{"type":"string"},"dsb":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"kab":{"type":"string"}},"required":["af","am","ar","ary","arz","ast","az","ba","be","be-tarask","bg","bn","br","bs","ca","ce","chr","ckb","crh","cs","csb","cv","cy","da","dag","de","diq","dsb","el","en","en-ca","en-gb","en-us","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fy","ga","gd","gl","gn","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","hyw","ia","id","ig","ilo","is","it","ja","ka","kaa","kab","kcg","kk","kn","ko","ks","ksh","ku","kw","la","lb","lt","lv","mg","min","mk","ml","mni","mr","ms","ms-arab","mt","my","mzn","nb","nds","ne","nl","nn","nqo","oc","or","pa","pap","pcm","pl","pnb","ps","pt","pt-br","rgn","ro","ru","scn","sco","se","sh","sk","sl","smn","sms","sq","sr","sr-ec","sr-el","sv","sw","szl","ta","te","tg","tg-cyrl","th","ti","tl","tr","ts","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","vmf","xmf","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "property-labels" with 156 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 2 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 1 schemas
 Unique normalised schemas (1 total):
   Schema 0:
@@ -3454,6 +3882,117 @@ Converting field "root" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(703 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(527 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"ryu":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"sd":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"ce":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"si":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"anp":{"type":"string"},"map-bms":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nl":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"azb":{"type":"string"},"mn":{"type":"string"},"mhr":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"hy":{"type":"string"},"ig":{"type":"string"},"sat":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"lo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"uz":{"type":"string"},"frr":{"type":"string"},"ckb":{"type":"string"},"xmf":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"nqo":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"awa":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"rn":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"ht":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"rue":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"fo":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"bew":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"}},"required":["af","ang","anp","ar","ary","arz","as","ast","awa","az","azb","ban","bar","bcl","be","be-tarask","bew","bg","bho","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","dty","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fur","fy","ga","gl","got","gu","hak","haw","he","hi","hr","hsb","ht","hu","hy","id","ig","ilo","io","is","it","ja","ka","kaa","kk","km","kn","ko","ks","ku","ky","la","lb","lo","lrc","lt","lv","lzh","map-bms","mhr","min","mk","ml","mn","mni","mr","ms","ms-arab","my","mzn","nan","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pap","pih","pl","pnb","ps","pt","pt-br","rn","ro","roa-tara","ru","rue","ryu","sa","sah","sat","sc","scn","sco","sd","se","sgs","sh","si","sk","sl","sn","sq","sr","sr-ec","sv","sw","ta","tcy","te","tg","tg-cyrl","th","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"bs":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"jv":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"fi":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","ary","arz","as","ast","az","ba","be","be-tarask","bg","bho","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","inh","io","is","it","ja","jv","ka","kaa","kk","kn","ko","ks","ksh","la","lb","lt","lv","mg","min","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","sh","sk","sl","sq","sr","sr-ec","sr-el","sv","ta","tcy","te","tg","tg-cyrl","th","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "mni": {
+...(691 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"ryu":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"sd":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"ce":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"si":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"anp":{"type":"string"},"map-bms":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nl":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"azb":{"type":"string"},"mn":{"type":"string"},"mhr":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"hy":{"type":"string"},"ig":{"type":"string"},"sat":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"lo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"uz":{"type":"string"},"frr":{"type":"string"},"ckb":{"type":"string"},"xmf":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"nqo":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"awa":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"rn":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"ht":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"rue":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"fo":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"bew":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"}},"required":["af","ang","anp","ar","ary","arz","as","ast","awa","az","azb","ban","bar","bcl","be","be-tarask","bew","bg","bho","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","dty","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fur","fy","ga","gl","got","gu","hak","haw","he","hi","hr","hsb","ht","hu","hy","id","ig","ilo","io","is","it","ja","ka","kaa","kk","km","kn","ko","ks","ku","ky","la","lb","lo","lrc","lt","lv","lzh","map-bms","mhr","min","mk","ml","mn","mni","mr","ms","ms-arab","my","mzn","nan","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pap","pih","pl","pnb","ps","pt","pt-br","rn","ro","roa-tara","ru","rue","ryu","sa","sah","sat","sc","scn","sco","sd","se","sgs","sh","si","sk","sl","sn","sq","sr","sr-ec","sv","sw","ta","tcy","te","tg","tg-cyrl","th","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 174 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 133 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:
@@ -4295,6 +4834,117 @@ Schemas not homogeneous, attempting unification
 Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(703 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(527 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"ryu":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"sd":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"ce":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"si":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"anp":{"type":"string"},"map-bms":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nl":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"azb":{"type":"string"},"mn":{"type":"string"},"mhr":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"hy":{"type":"string"},"ig":{"type":"string"},"sat":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"lo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"uz":{"type":"string"},"frr":{"type":"string"},"ckb":{"type":"string"},"xmf":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"nqo":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"awa":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"rn":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"ht":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"rue":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"fo":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"bew":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"}},"required":["af","ang","anp","ar","ary","arz","as","ast","awa","az","azb","ban","bar","bcl","be","be-tarask","bew","bg","bho","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","dty","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fur","fy","ga","gl","got","gu","hak","haw","he","hi","hr","hsb","ht","hu","hy","id","ig","ilo","io","is","it","ja","ka","kaa","kk","km","kn","ko","ks","ku","ky","la","lb","lo","lrc","lt","lv","lzh","map-bms","mhr","min","mk","ml","mn","mni","mr","ms","ms-arab","my","mzn","nan","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pap","pih","pl","pnb","ps","pt","pt-br","rn","ro","roa-tara","ru","rue","ryu","sa","sah","sat","sc","scn","sco","sd","se","sgs","sh","si","sk","sl","sn","sq","sr","sr-ec","sv","sw","ta","tcy","te","tg","tg-cyrl","th","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"bs":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"la":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"jv":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"ig":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"scn":{"type":"string"},"or":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"xmf":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"fi":{"type":"string"},"gpe":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"inh":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","an","ar","ary","arz","as","ast","az","ba","be","be-tarask","bg","bho","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","ga","gl","gpe","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","inh","io","is","it","ja","jv","ka","kaa","kk","kn","ko","ks","ksh","la","lb","lt","lv","mg","min","mk","ml","mr","ms","ms-arab","my","mzn","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pl","pnb","ps","pt","pt-br","ro","ru","scn","sco","sh","sk","sl","sq","sr","sr-ec","sr-el","sv","ta","tcy","te","tg","tg-cyrl","th","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "mni": {
+...(691 lines omitted)...
+    "zh-sg",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"ryu":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"zh-mo":{"type":"string"},"sd":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"sq":{"type":"string"},"ce":{"type":"string"},"tcy":{"type":"string"},"as":{"type":"string"},"si":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"anp":{"type":"string"},"map-bms":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"bho":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"nl":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"bar":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"azb":{"type":"string"},"mn":{"type":"string"},"mhr":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sah":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"hy":{"type":"string"},"ig":{"type":"string"},"sat":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"lo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"zh-cn":{"type":"string"},"uz":{"type":"string"},"frr":{"type":"string"},"ckb":{"type":"string"},"xmf":{"type":"string"},"is":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"min":{"type":"string"},"nqo":{"type":"string"},"ky":{"type":"string"},"zh-hk":{"type":"string"},"ast":{"type":"string"},"zh-tw":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"awa":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"ne":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"rn":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"dty":{"type":"string"},"ur":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"en-us":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"ht":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"zh-my":{"type":"string"},"rue":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"fo":{"type":"string"},"nds-nl":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"ilo":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"zu":{"type":"string"},"ru":{"type":"string"},"bew":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"}},"required":["af","ang","anp","ar","ary","arz","as","ast","awa","az","azb","ban","bar","bcl","be","be-tarask","bew","bg","bho","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","dty","el","en","en-ca","en-gb","en-us","eo","es","et","eu","fa","fi","fo","fr","frr","fur","fy","ga","gl","got","gu","hak","haw","he","hi","hr","hsb","ht","hu","hy","id","ig","ilo","io","is","it","ja","ka","kaa","kk","km","kn","ko","ks","ku","ky","la","lb","lo","lrc","lt","lv","lzh","map-bms","mhr","min","mk","ml","mn","mni","mr","ms","ms-arab","my","mzn","nan","nap","nb","nds","nds-nl","ne","nl","nn","nqo","oc","or","pa","pap","pih","pl","pnb","ps","pt","pt-br","rn","ro","roa-tara","ru","rue","ryu","sa","sah","sat","sc","scn","sco","sd","se","sgs","sh","si","sk","sl","sn","sq","sr","sr-ec","sv","sw","ta","tcy","te","tg","tg-cyrl","th","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 174 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 133 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
   Schema 0: {"properties":{"time":{"type":"string"},"timezone":{"type":"integer"},"before":{"type":"integer"},"after":{"type":"integer"},"precision":{"type":"integer"},"calendarmodel":{"type":"string"}},"required":["after","before","calendarmodel","precision","time","timezone"],"type":"object"}
   Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
   Schema 2: {"type":"string"}
@@ -4987,6 +5637,117 @@ Converting field "qualifiers" to map with schema:
     "type": "object"
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "labels": {
+...(919 lines omitted)...
+  "required": [
+    "id",
+    "labels"
+  ],
+  "type": "object"
+}
+  Schema 1:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "sr-ec": {
+...(595 lines omitted)...
+    "zh-my",
+    "zh-sg",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"properties":{"tt-cyrl":{"type":"string"},"be-tarask":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ie":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"os":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sat":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"tr":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"scn":{"type":"string"},"ku-latn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"min":{"type":"string"},"gn":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"kl":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"hyw":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"nrm":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"xh":{"type":"string"},"jam":{"type":"string"},"btm":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"kbd":{"type":"string"},"nb":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"bs":{"type":"string"},"sq":{"type":"string"},"yo":{"type":"string"},"map-bms":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"bar":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"lo":{"type":"string"},"el":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"lmo":{"type":"string"},"lt":{"type":"string"},"mg":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"arc":{"type":"string"},"lfn":{"type":"string"},"rue":{"type":"string"},"sr":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"kn":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"am":{"type":"string"},"tok":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"bew":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"lad":{"type":"string"},"de":{"type":"string"},"gcr":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"lij":{"type":"string"},"kab":{"type":"string"}},"required":["aeb-arab","af","am","an","ang","anp","ar","arc","ary","arz","as","ast","az","azb","ba","bar","bbc","be","be-tarask","bew","bg","bn","br","bs","btm","ca","cdo","ce","ceb","chy","ckb","co","crh","crh-latn","cs","cv","cy","da","de","diq","dsb","dv","el","eml","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fo","fr","frp","frr","fy","ga","gcr","gd","gl","gn","got","gpe","gsw","gu","gv","hak","haw","he","hi","hif","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ilo","io","is","it","ja","jam","jv","ka","kaa","kab","kbd","kbp","kk","kl","km","kn","ko","koi","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lfn","li","lij","lld","lmo","ln","lo","lt","lv","map-bms","mdf","mg","mhr","mi","min","mk","ml","mni","mr","ms","ms-arab","mt","my","mzn","na","nah","nan","nb","nds","nds-nl","new","nl","nn","nov","nqo","nrm","nso","oc","os","pa","pap","pcd","pdc","pfl","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","ro","ru","rue","sa","sah","sat","sc","scn","sco","se","sh","sk","sl","sm","smn","so","sq","sr","sr-ec","srn","st","stq","su","sv","sw","szl","ta","te","tg","th","ti","tl","tly","tn","to","tok","tr","tt","tt-cyrl","ug","uk","ur","uz","vec","vep","vi","vls","vo","vro","wa","war","wuu","xh","xmf","yi","yo","yue","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":"object"}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"sr-ec":{"type":"string"},"be-tarask":{"type":"string"},"kcg":{"type":"string"},"it":{"type":"string"},"ha":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"pnb":{"type":"string"},"ks":{"type":"string"},"zh-mo":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"zh-hant":{"type":"string"},"ro":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"ce":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"sq":{"type":"string"},"hr":{"type":"string"},"bs":{"type":"string"},"as":{"type":"string"},"yo":{"type":"string"},"ban":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"la":{"type":"string"},"nn":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"af":{"type":"string"},"ia":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"sma":{"type":"string"},"my":{"type":"string"},"bar":{"type":"string"},"ml":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ig":{"type":"string"},"sv":{"type":"string"},"sr-el":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"tr":{"type":"string"},"be":{"type":"string"},"dag":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"no":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"zh-sg":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"ku-latn":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"xmf":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"is":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"oc":{"type":"string"},"yue":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"lmo":{"type":"string"},"ms":{"type":"string"},"sms":{"type":"string"},"lt":{"type":"string"},"sjd":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"rmf":{"type":"string"},"ko":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"hsb":{"type":"string"},"syl":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"udm":{"type":"string"},"io":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"zh-my":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"nds-nl":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ps":{"type":"string"},"nap":{"type":"string"},"ga":{"type":"string"},"pap-aw":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"smj":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"fa":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"}},"required":["af","ar","ary","arz","as","ast","az","ba","ban","bar","be","be-tarask","bg","bn","br","bs","ca","ce","ckb","cs","cy","da","dag","de","diq","el","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fr","frr","fy","ga","gd","gl","gsw","gu","ha","he","hi","hr","hsb","hu","hy","ia","id","ig","ilo","io","is","it","ja","ka","kaa","kcg","kk","ko","ks","ku-latn","la","lb","lmo","lt","lv","mhr","mk","ml","mr","ms","ms-arab","mt","my","mzn","nap","nb","nds","nds-nl","nl","nn","no","nqo","oc","or","pa","pap","pap-aw","pl","pnb","ps","pt","pt-br","rmf","ro","ru","sah","scn","sco","se","sh","sjd","sk","sl","sma","smj","smn","sms","sq","sr","sr-ec","sr-el","su","sv","syl","ta","te","tg","tg-cyrl","th","ti","tl","tly","tok","tr","tt","tt-cyrl","udm","uk","ur","uz","vec","vi","xmf","yi","yo","yue","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-mo","zh-my","zh-sg","zh-tw"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "be-tarask": {
+...(907 lines omitted)...
+    "zh-hk",
+    "zh-tw",
+    "zu"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"be-tarask":{"type":"string"},"ln":{"type":"string"},"it":{"type":"string"},"pnb":{"type":"string"},"cdo":{"type":"string"},"ie":{"type":"string"},"bbc":{"type":"string"},"ce":{"type":"string"},"anp":{"type":"string"},"tt":{"type":"string"},"aeb-arab":{"type":"string"},"diq":{"type":"string"},"ka":{"type":"string"},"hr":{"type":"string"},"as":{"type":"string"},"pap":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ia":{"type":"string"},"lld":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"azb":{"type":"string"},"ml":{"type":"string"},"os":{"type":"string"},"chy":{"type":"string"},"jv":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"sat":{"type":"string"},"sv":{"type":"string"},"be":{"type":"string"},"tr":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"sa":{"type":"string"},"szl":{"type":"string"},"scn":{"type":"string"},"ku-latn":{"type":"string"},"ta":{"type":"string"},"ary":{"type":"string"},"su":{"type":"string"},"zh-cn":{"type":"string"},"frr":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"nqo":{"type":"string"},"is":{"type":"string"},"min":{"type":"string"},"gn":{"type":"string"},"pt-br":{"type":"string"},"dv":{"type":"string"},"kl":{"type":"string"},"eml":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"hyw":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"nrm":{"type":"string"},"es":{"type":"string"},"so":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"koi":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"got":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mk":{"type":"string"},"hi":{"type":"string"},"xh":{"type":"string"},"jam":{"type":"string"},"btm":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"ti":{"type":"string"},"se":{"type":"string"},"fi":{"type":"string"},"na":{"type":"string"},"io":{"type":"string"},"sw":{"type":"string"},"fr":{"type":"string"},"hak":{"type":"string"},"nds-nl":{"type":"string"},"pcd":{"type":"string"},"kk":{"type":"string"},"rm":{"type":"string"},"kaa":{"type":"string"},"nah":{"type":"string"},"gd":{"type":"string"},"id":{"type":"string"},"ps":{"type":"string"},"nso":{"type":"string"},"zu":{"type":"string"},"cv":{"type":"string"},"mdf":{"type":"string"},"kbp":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"gu":{"type":"string"},"vi":{"type":"string"},"pms":{"type":"string"},"vls":{"type":"string"},"ksh":{"type":"string"},"mzn":{"type":"string"},"sk":{"type":"string"},"sh":{"type":"string"},"ug":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"sr-ec":{"type":"string"},"pih":{"type":"string"},"haw":{"type":"string"},"yi":{"type":"string"},"kbd":{"type":"string"},"nb":{"type":"string"},"war":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"qu":{"type":"string"},"ro":{"type":"string"},"st":{"type":"string"},"gl":{"type":"string"},"zh-hant":{"type":"string"},"bs":{"type":"string"},"sq":{"type":"string"},"yo":{"type":"string"},"map-bms":{"type":"string"},"co":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"bar":{"type":"string"},"smn":{"type":"string"},"mhr":{"type":"string"},"vro":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"sah":{"type":"string"},"ba":{"type":"string"},"bg":{"type":"string"},"lo":{"type":"string"},"el":{"type":"string"},"frp":{"type":"string"},"uz":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"to":{"type":"string"},"li":{"type":"string"},"vo":{"type":"string"},"oc":{"type":"string"},"gv":{"type":"string"},"yue":{"type":"string"},"new":{"type":"string"},"lmo":{"type":"string"},"lt":{"type":"string"},"mg":{"type":"string"},"mr":{"type":"string"},"mt":{"type":"string"},"nov":{"type":"string"},"an":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"gsw":{"type":"string"},"en":{"type":"string"},"wa":{"type":"string"},"srn":{"type":"string"},"cs":{"type":"string"},"kw":{"type":"string"},"sm":{"type":"string"},"crh-latn":{"type":"string"},"gpe":{"type":"string"},"ang":{"type":"string"},"cy":{"type":"string"},"ht":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"arc":{"type":"string"},"lfn":{"type":"string"},"rue":{"type":"string"},"sr":{"type":"string"},"fo":{"type":"string"},"zea":{"type":"string"},"kn":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"ilo":{"type":"string"},"tly":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"th":{"type":"string"},"crh":{"type":"string"},"pdc":{"type":"string"},"ga":{"type":"string"},"hif":{"type":"string"},"am":{"type":"string"},"tok":{"type":"string"},"tn":{"type":"string"},"ru":{"type":"string"},"kv":{"type":"string"},"bew":{"type":"string"},"pfl":{"type":"string"},"mi":{"type":"string"},"ceb":{"type":"string"},"zgh":{"type":"string"},"tg":{"type":"string"},"lad":{"type":"string"},"de":{"type":"string"},"gcr":{"type":"string"},"lb":{"type":"string"},"stq":{"type":"string"},"dsb":{"type":"string"},"fa":{"type":"string"},"lij":{"type":"string"},"kab":{"type":"string"}},"required":["aeb-arab","af","am","an","ang","anp","ar","arc","ary","arz","as","ast","az","azb","ba","bar","bbc","be","be-tarask","bew","bg","bn","br","bs","btm","ca","cdo","ce","ceb","chy","ckb","co","crh","crh-latn","cs","cv","cy","da","de","diq","dsb","dv","el","eml","en","en-ca","en-gb","eo","es","et","eu","fa","fi","fo","fr","frp","frr","fy","ga","gcr","gd","gl","gn","got","gpe","gsw","gu","gv","hak","haw","he","hi","hif","hr","hsb","ht","hu","hy","hyw","ia","id","ie","ilo","io","is","it","ja","jam","jv","ka","kaa","kab","kbd","kbp","kk","kl","km","kn","ko","koi","ksh","ku","ku-latn","kv","kw","ky","la","lad","lb","lfn","li","lij","lld","lmo","ln","lo","lt","lv","map-bms","mdf","mg","mhr","mi","min","mk","ml","mni","mr","ms","ms-arab","mt","my","mzn","na","nah","nan","nb","nds","nds-nl","new","nl","nn","nov","nqo","nrm","nso","oc","os","pa","pap","pcd","pdc","pfl","pih","pl","pms","pnb","ps","pt","pt-br","qu","rm","ro","ru","rue","sa","sah","sat","sc","scn","sco","se","sh","sk","sl","sm","smn","so","sq","sr","sr-ec","srn","st","stq","su","sv","sw","szl","ta","te","tg","th","ti","tl","tly","tn","to","tok","tr","tt","tt-cyrl","ug","uk","ur","uz","vec","vep","vi","vls","vo","vro","wa","war","wuu","xh","xmf","yi","yo","yue","zea","zgh","zh","zh-cn","zh-hans","zh-hant","zh-hk","zh-tw","zu"],"type":"object"}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 228 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 150 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 1: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"id":{"type":"string"},"labels":{"type":"object","additionalProperties":{"type":"string"}}},"required":["id","labels"],"type":"object"}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 2 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (2 total):
   Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
@@ -5713,6 +6474,117 @@ Converting field "root" to map with schema:
     ]
   }
 }
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0:
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+...(519 lines omitted)...
+        "null",
+        "string"
+      ]
+    }
+  }
+}
+  Schema 1:
+{
+  "type": "object",
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+...(671 lines omitted)...
+    "vi",
+    "de",
+    "fa",
+    "sk"
+  ]
+}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":["null","object"]},"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","properties":{"tt-cyrl":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"nb":{"type":"string"},"ks":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"bs":{"type":"string"},"tt":{"type":"string"},"hr":{"type":"string"},"bho":{"type":"string"},"nl":{"type":"string"},"af":{"type":"string"},"he":{"type":"string"},"ar":{"type":"string"},"nn":{"type":"string"},"sl":{"type":"string"},"my":{"type":"string"},"ml":{"type":"string"},"pl":{"type":"string"},"lv":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"dag":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"ta":{"type":"string"},"zh-cn":{"type":"string"},"uz":{"type":"string"},"da":{"type":"string"},"zh-hk":{"type":"string"},"zh-tw":{"type":"string"},"az":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"lt":{"type":"string"},"en-gb":{"type":"string"},"vec":{"type":"string"},"ko":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"fi":{"type":"string"},"ja":{"type":"string"},"hu":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"bn":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"kaa":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"ru":{"type":"string"},"et":{"type":"string"},"vi":{"type":"string"},"de":{"type":"string"},"fa":{"type":"string"},"sk":{"type":"string"},"sr-ec":{"type":["null","string"]},"ha":{"type":["null","string"]},"yi":{"type":["null","string"]},"pnb":{"type":["null","string"]},"zh-mo":{"type":["null","string"]},"nds":{"type":["null","string"]},"sco":{"type":["null","string"]},"ro":{"type":["null","string"]},"ka":{"type":["null","string"]},"ce":{"type":["null","string"]},"sq":{"type":["null","string"]},"tcy":{"type":["null","string"]},"as":{"type":["null","string"]},"en-ca":{"type":["null","string"]},"arz":{"type":["null","string"]},"la":{"type":["null","string"]},"ia":{"type":["null","string"]},"eu":{"type":["null","string"]},"jv":{"type":["null","string"]},"hy":{"type":["null","string"]},"pa":{"type":["null","string"]},"ig":{"type":["null","string"]},"bg":{"type":["null","string"]},"sr-el":{"type":["null","string"]},"ba":{"type":["null","string"]},"br":{"type":["null","string"]},"el":{"type":["null","string"]},"zh-sg":{"type":["null","string"]},"scn":{"type":["null","string"]},"or":{"type":["null","string"]},"ary":{"type":["null","string"]},"xmf":{"type":["null","string"]},"ckb":{"type":["null","string"]},"nqo":{"type":["null","string"]},"is":{"type":["null","string"]},"pt-br":{"type":["null","string"]},"min":{"type":["null","string"]},"ast":{"type":["null","string"]},"oc":{"type":["null","string"]},"yue":{"type":["null","string"]},"te":{"type":["null","string"]},"mg":{"type":["null","string"]},"mr":{"type":["null","string"]},"ne":{"type":["null","string"]},"an":{"type":["null","string"]},"hsb":{"type":["null","string"]},"gsw":{"type":["null","string"]},"ur":{"type":["null","string"]},"gpe":{"type":["null","string"]},"cy":{"type":["null","string"]},"udm":{"type":["null","string"]},"io":{"type":["null","string"]},"zh-my":{"type":["null","string"]},"tg-cyrl":{"type":["null","string"]},"nds-nl":{"type":["null","string"]},"kn":{"type":["null","string"]},"kk":{"type":["null","string"]},"ilo":{"type":["null","string"]},"ps":{"type":["null","string"]},"nap":{"type":["null","string"]},"ga":{"type":["null","string"]},"zu":{"type":["null","string"]},"inh":{"type":["null","string"]},"gu":{"type":["null","string"]},"tg":{"type":["null","string"]},"lb":{"type":["null","string"]},"ksh":{"type":["null","string"]},"mzn":{"type":["null","string"]},"sh":{"type":["null","string"]},"mos":{"type":["null","string"]}},"required":["tt-cyrl","be-tarask","it","nb","ks","zh-hant","gl","bs","tt","hr","bho","nl","af","he","ar","nn","sl","my","ml","pl","lv","pt","be","sv","tr","dag","eo","uk","ta","zh-cn","uz","da","zh-hk","zh-tw","az","es","ms","lt","en-gb","vec","ko","hi","mk","ms-arab","ca","en","cs","fi","ja","hu","sr","fr","bn","zh","zh-hans","kaa","id","th","ru","et","vi","de","fa","sk"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0:
+{
+  "properties": {
+    "tt-cyrl": {
+      "type": "string"
+    },
+    "mni": {
+...(499 lines omitted)...
+    "zh-hans",
+    "zh-hant",
+    "zh-tw"
+  ],
+  "type": "object"
+}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"properties":{"tt-cyrl":{"type":"string"},"mni":{"type":"string"},"km":{"type":"string"},"be-tarask":{"type":"string"},"it":{"type":"string"},"yi":{"type":"string"},"nb":{"type":"string"},"de-ch":{"type":"string"},"nds":{"type":"string"},"sco":{"type":"string"},"ro":{"type":"string"},"zh-hant":{"type":"string"},"gl":{"type":"string"},"ka":{"type":"string"},"tt":{"type":"string"},"diq":{"type":"string"},"bs":{"type":"string"},"hr":{"type":"string"},"ce":{"type":"string"},"as":{"type":"string"},"fur":{"type":"string"},"bxr":{"type":"string"},"map-bms":{"type":"string"},"en-ca":{"type":"string"},"arz":{"type":"string"},"af":{"type":"string"},"la":{"type":"string"},"ar":{"type":"string"},"he":{"type":"string"},"ext":{"type":"string"},"nl":{"type":"string"},"sl":{"type":"string"},"eu":{"type":"string"},"my":{"type":"string"},"sc":{"type":"string"},"sn":{"type":"string"},"ml":{"type":"string"},"mn":{"type":"string"},"vep":{"type":"string"},"pl":{"type":"string"},"hy":{"type":"string"},"lv":{"type":"string"},"pa":{"type":"string"},"pt":{"type":"string"},"be":{"type":"string"},"sv":{"type":"string"},"tr":{"type":"string"},"bg":{"type":"string"},"br":{"type":"string"},"eo":{"type":"string"},"uk":{"type":"string"},"el":{"type":"string"},"or":{"type":"string"},"scn":{"type":"string"},"ta":{"type":"string"},"frr":{"type":"string"},"uz":{"type":"string"},"xmf":{"type":"string"},"ckb":{"type":"string"},"zh-cn":{"type":"string"},"ky":{"type":"string"},"da":{"type":"string"},"pt-br":{"type":"string"},"zh-tw":{"type":"string"},"ast":{"type":"string"},"vo":{"type":"string"},"yue":{"type":"string"},"oc":{"type":"string"},"az":{"type":"string"},"te":{"type":"string"},"es":{"type":"string"},"ms":{"type":"string"},"wuu":{"type":"string"},"lt":{"type":"string"},"lrc":{"type":"string"},"en-gb":{"type":"string"},"mg":{"type":"string"},"ko":{"type":"string"},"ku":{"type":"string"},"mr":{"type":"string"},"lzh":{"type":"string"},"hi":{"type":"string"},"mk":{"type":"string"},"hsb":{"type":"string"},"ms-arab":{"type":"string"},"ca":{"type":"string"},"en":{"type":"string"},"cs":{"type":"string"},"ur":{"type":"string"},"tl":{"type":"string"},"fi":{"type":"string"},"cy":{"type":"string"},"bcl":{"type":"string"},"hu":{"type":"string"},"ja":{"type":"string"},"sw":{"type":"string"},"tg-cyrl":{"type":"string"},"sr":{"type":"string"},"fr":{"type":"string"},"fo":{"type":"string"},"hak":{"type":"string"},"kn":{"type":"string"},"kk":{"type":"string"},"bn":{"type":"string"},"fy":{"type":"string"},"sgs":{"type":"string"},"zh":{"type":"string"},"zh-hans":{"type":"string"},"id":{"type":"string"},"th":{"type":"string"},"cv":{"type":"string"},"ga":{"type":"string"},"tok":{"type":"string"},"ru":{"type":"string"},"nan":{"type":"string"},"et":{"type":"string"},"roa-tara":{"type":"string"},"vi":{"type":"string"},"tg":{"type":"string"},"de":{"type":"string"},"lb":{"type":"string"},"lij":{"type":"string"},"fa":{"type":"string"},"sh":{"type":"string"},"sk":{"type":"string"},"kab":{"type":"string"}},"required":["af","ar","arz","as","ast","az","bcl","be","be-tarask","bg","bn","br","bs","bxr","ca","ce","ckb","cs","cv","cy","da","de","de-ch","diq","el","en","en-ca","en-gb","eo","es","et","eu","ext","fa","fi","fo","fr","frr","fur","fy","ga","gl","hak","he","hi","hr","hsb","hu","hy","id","it","ja","ka","kab","kk","km","kn","ko","ku","ky","la","lb","lij","lrc","lt","lv","lzh","map-bms","mg","mk","ml","mn","mni","mr","ms","ms-arab","my","nan","nb","nds","nl","oc","or","pa","pl","pt","pt-br","ro","roa-tara","ru","sc","scn","sco","sgs","sh","sk","sl","sn","sr","sv","sw","ta","te","tg","tg-cyrl","th","tl","tok","tr","tt","tt-cyrl","uk","ur","uz","vep","vi","vo","wuu","xmf","yi","yue","zh","zh-cn","zh-hans","zh-hant","zh-tw"],"type":["null","object"]}
+Not converting to map: no unified schema
+Checking homogeneity for field "labels" with 126 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "property-labels" with 134 schemas
+Unique normalised schemas (1 total):
+  Schema 0: {"type":"string"}
+Schemas are homogeneous after normalisation
+Checking if should convert to map: above_threshold=true, unified_schema=Some
+Map conversion: no max_required_keys limit, converting to map
+Converting field "property-labels" to map with schema:
+{
+  "type": "string"
+}
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 4 schemas
+Unique normalised schemas (3 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"datavalue__string":{"type":["null","string"]}}}
+  Schema 2: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","properties":{"id":{"type":["null","string"]},"labels":{"type":"object","additionalProperties":{"type":"string"}},"datavalue__string":{"type":["null","string"]}}}
+  Schema 3 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "datavalue" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+datavalue: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
+Checking homogeneity for field "root" with 3 schemas
+Unique normalised schemas (2 total):
+  Schema 0: {"type":"object","additionalProperties":{"type":"string"}}
+  Schema 1: {"type":"string"}
+Schemas not homogeneous, attempting unification
+: Not all schemas are scalars
+  Schema 1 (NOT scalar): {"type":"object","additionalProperties":{"type":"string"}}
+Not converting to map: no unified schema
 Checking homogeneity for field "root" with 4 schemas
 Unique normalised schemas (3 total):
   Schema 0:

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__avro.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__avro.snap
@@ -38,54 +38,52 @@ info:
         "values": {
           "name": "claims_values",
           "type": "map",
-          "values": [
-            {
-              "type": "record",
-              "name": "claims_values_values",
-              "namespace": "genson.document_types",
-              "fields": [
-                {
-                  "name": "timezone",
-                  "type": [
-                    "null",
-                    "int"
-                  ]
-                },
-                {
-                  "name": "precision",
-                  "type": [
-                    "null",
-                    "int"
-                  ]
-                },
-                {
-                  "name": "id",
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                {
-                  "name": "labels",
-                  "type": [
-                    "null",
-                    {
-                      "type": "record",
-                      "name": "labels",
-                      "namespace": "genson.document_types.claims_values_values_types",
-                      "fields": [
-                        {
-                          "name": "en",
-                          "type": "string"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "string"
-          ]
+          "values": {
+            "type": "record",
+            "name": "claims_values_values",
+            "namespace": "genson.document_types",
+            "fields": [
+              {
+                "name": "timezone",
+                "type": [
+                  "null",
+                  "int"
+                ]
+              },
+              {
+                "name": "precision",
+                "type": [
+                  "null",
+                  "int"
+                ]
+              },
+              {
+                "name": "id",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              {
+                "name": "labels",
+                "type": [
+                  "null",
+                  {
+                    "name": "labels",
+                    "type": "map",
+                    "values": "string"
+                  }
+                ]
+              },
+              {
+                "name": "datavalue__string",
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            ]
+          }
         }
       }
     }

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__avro.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__avro.snap
@@ -1,0 +1,93 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+    - "--avro"
+  input:
+    - claims:
+        P31:
+          datavalue: string-value
+    - claims:
+        P31:
+          datavalue:
+            timezone: 0
+            precision: 11
+    - claims:
+        P31:
+          datavalue:
+            id: X
+            labels:
+              en: thing
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "genson",
+  "fields": [
+    {
+      "name": "claims",
+      "type": {
+        "name": "claims",
+        "type": "map",
+        "values": {
+          "name": "claims_values",
+          "type": "map",
+          "values": [
+            {
+              "type": "record",
+              "name": "claims_values_values",
+              "namespace": "genson.document_types",
+              "fields": [
+                {
+                  "name": "timezone",
+                  "type": [
+                    "null",
+                    "int"
+                  ]
+                },
+                {
+                  "name": "precision",
+                  "type": [
+                    "null",
+                    "int"
+                  ]
+                },
+                {
+                  "name": "id",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                {
+                  "name": "labels",
+                  "type": [
+                    "null",
+                    {
+                      "type": "record",
+                      "name": "labels",
+                      "namespace": "genson.document_types.claims_values_values_types",
+                      "fields": [
+                        {
+                          "name": "en",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "string"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__jsonschema.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__jsonschema.snap
@@ -32,36 +32,39 @@ info:
       "additionalProperties": {
         "type": "object",
         "additionalProperties": {
-          "anyOf": [
-            {
-              "properties": {
-                "timezone": {
-                  "type": "integer"
-                },
-                "precision": {
-                  "type": "integer"
-                },
-                "id": {
-                  "type": "string"
-                },
-                "labels": {
-                  "properties": {
-                    "en": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "en"
-                  ],
-                  "type": "object"
-                }
-              },
-              "type": "object"
+          "type": "object",
+          "properties": {
+            "timezone": {
+              "type": [
+                "null",
+                "integer"
+              ]
             },
-            {
-              "type": "string"
+            "precision": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "datavalue__string": {
+              "type": [
+                "null",
+                "string"
+              ]
             }
-          ]
+          }
         }
       }
     }

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__jsonschema.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__jsonschema.snap
@@ -1,0 +1,73 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+  input:
+    - claims:
+        P31:
+          datavalue: string-value
+    - claims:
+        P31:
+          datavalue:
+            timezone: 0
+            precision: 11
+    - claims:
+        P31:
+          datavalue:
+            id: X
+            labels:
+              en: thing
+---
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "claims": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "properties": {
+                "timezone": {
+                  "type": "integer"
+                },
+                "precision": {
+                  "type": "integer"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "labels": {
+                  "properties": {
+                    "en": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "en"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "claims"
+  ],
+  "type": "object"
+}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__normalize.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__normalize.snap
@@ -1,0 +1,30 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+    - "--normalise"
+  input:
+    - claims:
+        P31:
+          datavalue: string-value
+    - claims:
+        P31:
+          datavalue:
+            timezone: 0
+            precision: 11
+    - claims:
+        P31:
+          datavalue:
+            id: X
+            labels:
+              en: thing
+---
+{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":null,"labels":null}}}}
+{"claims":{"P31":{"datavalue":{"timezone":0,"precision":11,"id":null,"labels":null}}}}
+{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":"X","labels":{"en":"thing"}}}}}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__normalize.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__nested_anyof__normalize.snap
@@ -25,6 +25,6 @@ info:
             labels:
               en: thing
 ---
-{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":null,"labels":null}}}}
-{"claims":{"P31":{"datavalue":{"timezone":0,"precision":11,"id":null,"labels":null}}}}
-{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":"X","labels":{"en":"thing"}}}}}
+{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":null,"labels":null,"datavalue__string":"string-value"}}}}
+{"claims":{"P31":{"datavalue":{"timezone":0,"precision":11,"id":null,"labels":null,"datavalue__string":null}}}}
+{"claims":{"P31":{"datavalue":{"timezone":null,"precision":null,"id":"X","labels":{"en":"thing"},"datavalue__string":null}}}}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__avro.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__avro.snap
@@ -1,0 +1,77 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+    - "--avro"
+  input:
+    - datavalue: string-value
+    - datavalue:
+        timezone: 0
+        precision: 11
+    - datavalue:
+        id: X
+        labels:
+          en: thing
+---
+{
+  "type": "record",
+  "name": "document",
+  "namespace": "genson",
+  "fields": [
+    {
+      "name": "datavalue",
+      "type": {
+        "type": "record",
+        "name": "datavalue",
+        "namespace": "genson.document_types",
+        "fields": [
+          {
+            "name": "timezone",
+            "type": [
+              "null",
+              "int"
+            ]
+          },
+          {
+            "name": "precision",
+            "type": [
+              "null",
+              "int"
+            ]
+          },
+          {
+            "name": "id",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "labels",
+            "type": [
+              "null",
+              {
+                "name": "labels",
+                "type": "map",
+                "values": "string"
+              }
+            ]
+          },
+          {
+            "name": "datavalue__string",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__jsonschema.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__jsonschema.snap
@@ -1,0 +1,64 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+  input:
+    - datavalue: string-value
+    - datavalue:
+        timezone: 0
+        precision: 11
+    - datavalue:
+        id: X
+        labels:
+          en: thing
+---
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "datavalue": {
+      "type": "object",
+      "properties": {
+        "timezone": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "precision": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "datavalue__string": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "datavalue"
+  ],
+  "type": "object"
+}

--- a/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__normalize.snap
+++ b/genson-cli/tests/snapshots/unify_anyof_scalar__root_anyof__normalize.snap
@@ -1,0 +1,24 @@
+---
+source: genson-cli/tests/unify_anyof_scalar.rs
+expression: stdout_str
+info:
+  approved: false
+  args:
+    - "--ndjson"
+    - "--map-threshold"
+    - "1"
+    - "--unify-maps"
+    - "--normalise"
+  input:
+    - datavalue: string-value
+    - datavalue:
+        timezone: 0
+        precision: 11
+    - datavalue:
+        id: X
+        labels:
+          en: thing
+---
+{"datavalue":{"timezone":null,"precision":null,"id":null,"labels":null,"datavalue__string":"string-value"}}
+{"datavalue":{"timezone":0,"precision":11,"id":null,"labels":null,"datavalue__string":null}}
+{"datavalue":{"timezone":null,"precision":null,"id":"X","labels":{"en":"thing"},"datavalue__string":null}}

--- a/genson-cli/tests/unify_anyof_scalar.rs
+++ b/genson-cli/tests/unify_anyof_scalar.rs
@@ -1,0 +1,125 @@
+use assert_cmd::Command;
+use insta::{assert_snapshot, with_settings};
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// Helper: write lines of NDJSON to a temp file
+fn write_ndjson(rows: &[&str]) -> NamedTempFile {
+    let mut temp = NamedTempFile::new().unwrap();
+    for row in rows {
+        writeln!(temp, "{}", row).unwrap();
+    }
+    temp
+}
+
+/// Check if the current output matches the verified/blessed version
+fn is_output_approved(snapshot_name: &str, output: &str) -> bool {
+    let module_file = file!();
+    let module_stem = std::path::Path::new(module_file)
+        .file_stem()
+        .unwrap()
+        .to_string_lossy();
+    let verified_path = format!("tests/verified/{}__{}.snap", module_stem, snapshot_name);
+
+    if let Ok(verified_content) = fs::read_to_string(&verified_path) {
+        if let Some(header_end) = verified_content.find("\n---\n") {
+            let verified_output = &verified_content[header_end + 5..];
+            return verified_output.trim() == output.trim();
+        }
+    }
+    false
+}
+
+/// Run genson-cli with anyOf scalar promotion settings
+fn run_genson_anyof_promotion(name: &str, rows: Vec<&str>, extra_args: &[&str]) {
+    let temp = write_ndjson(&rows);
+
+    let mut cmd = Command::cargo_bin("genson-cli").unwrap();
+    let mut args = vec!["--ndjson", "--map-threshold", "1", "--unify-maps"];
+    args.extend_from_slice(extra_args);
+    args.push(temp.path().to_str().unwrap());
+    let args_for_metadata = args.clone();
+    cmd.args(args);
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let stdout_str = String::from_utf8(output).unwrap();
+
+    let input_json: Vec<Value> = rows
+        .into_iter()
+        .map(|s| serde_json::from_str::<Value>(s).unwrap())
+        .collect();
+
+    let approved = is_output_approved(name, &stdout_str);
+
+    with_settings!({
+        info => &serde_json::json!({
+            "approved": approved,
+            "args": args_for_metadata[..args_for_metadata.len()-1],
+            "input": input_json
+        })
+    }, {
+        assert_snapshot!(name, stdout_str);
+    });
+}
+
+/// Root level anyOf case: datavalue directly under root
+fn root_level_anyof_rows() -> Vec<&'static str> {
+    vec![
+        r#"{"datavalue": "string-value"}"#,
+        r#"{"datavalue": {"timezone": 0, "precision": 11}}"#,
+        r#"{"datavalue": {"id": "X", "labels": {"en": "thing"}}}"#,
+    ]
+}
+
+/// Nested anyOf case: datavalue nested under claims.P31 (mimicking wikidata)
+fn nested_anyof_rows() -> Vec<&'static str> {
+    vec![
+        r#"{"claims": {"P31": {"datavalue": "string-value"}}}"#,
+        r#"{"claims": {"P31": {"datavalue": {"timezone": 0, "precision": 11}}}}"#,
+        r#"{"claims": {"P31": {"datavalue": {"id": "X", "labels": {"en": "thing"}}}}}"#,
+    ]
+}
+
+// Root level anyOf tests
+
+#[test]
+fn test_root_anyof_jsonschema() {
+    run_genson_anyof_promotion("root_anyof__jsonschema", root_level_anyof_rows(), &[]);
+}
+
+#[test]
+fn test_root_anyof_avro() {
+    run_genson_anyof_promotion("root_anyof__avro", root_level_anyof_rows(), &["--avro"]);
+}
+
+#[test]
+fn test_root_anyof_normalize() {
+    run_genson_anyof_promotion(
+        "root_anyof__normalize",
+        root_level_anyof_rows(),
+        &["--normalise"],
+    );
+}
+
+// Nested anyOf tests
+
+#[test]
+fn test_nested_anyof_jsonschema() {
+    run_genson_anyof_promotion("nested_anyof__jsonschema", nested_anyof_rows(), &[]);
+}
+
+#[test]
+fn test_nested_anyof_avro() {
+    run_genson_anyof_promotion("nested_anyof__avro", nested_anyof_rows(), &["--avro"]);
+}
+
+#[test]
+fn test_nested_anyof_normalize() {
+    run_genson_anyof_promotion(
+        "nested_anyof__normalize",
+        nested_anyof_rows(),
+        &["--normalise"],
+    );
+}

--- a/genson-core/src/schema/map_inference.rs
+++ b/genson-core/src/schema/map_inference.rs
@@ -100,7 +100,7 @@ pub(crate) fn rewrite_objects(
                     any_of_schemas.len()
                 );
                 if let Some(unified) =
-                    check_unifiable_schemas(any_of_schemas, field_name.unwrap_or(""), config)
+                    unify_anyof_schemas(any_of_schemas, field_name.unwrap_or(""), config)
                 {
                     debug!(config, "Successfully unified anyOf schemas");
                     // Replace the entire schema with the unified result

--- a/genson-core/src/schema/map_inference.rs
+++ b/genson-core/src/schema/map_inference.rs
@@ -286,7 +286,7 @@ pub(crate) fn rewrite_objects(
             // Apply map inference logic
             let should_be_map = if above_threshold && unified_schema.is_some() {
                 // Don't convert to map if the unified schema contains anyOf - let it be processed first
-                if contains_anyof(unified_schema.as_ref().unwrap()) {
+                if unified_schema.as_ref().is_some_and(contains_anyof) {
                     debug!(config, "Not converting to map: unified schema contains anyOf that needs processing");
                     false
                 } else {

--- a/genson-core/src/schema/map_inference/unification.rs
+++ b/genson-core/src/schema/map_inference/unification.rs
@@ -376,37 +376,6 @@ pub(crate) fn check_unifiable_schemas(
                 "{}: All schemas are scalars, attempting scalar unification", path
             );
             return unify_scalar_schemas(schemas, path, config);
-        // } else if config.wrap_scalars && schemas.iter().any(is_scalar_schema) && schemas.iter().any(is_object_schema) {
-        //     // Mixed scalar+object schemas with wrap_scalars enabled - promote scalars then proceed
-        //     debug!(config, "{}: Mixed scalar+object schemas, proceeding with scalar promotion", path);
-        //
-        //     let field_name = path.split('.').last().unwrap_or("");
-        //     let mut promoted_schemas = Vec::new();
-        //
-        //     for schema in schemas {
-        //         if is_scalar_schema(schema) {
-        //             if let Some(scalar_type) = get_scalar_type_name(schema) {
-        //                 let wrapped_key = make_promoted_scalar_key(field_name, &scalar_type);
-        //                 let promoted = json!({
-        //                     "type": "object",
-        //                     "properties": {
-        //                         wrapped_key.clone(): schema.clone()
-        //                     }
-        //                 });
-        //                 debug!(config, "{}: Promoted scalar {} to object with key {}", path, scalar_type, wrapped_key);
-        //                 promoted_schemas.push(promoted);
-        //             } else {
-        //                 debug!(config, "{}: Failed to get scalar type for promotion", path);
-        //                 return None;
-        //             }
-        //         } else {
-        //             promoted_schemas.push(schema.clone());
-        //         }
-        //     }
-        //
-        //     // Recursively call with promoted schemas (now all objects)
-        //     debug!(config, "RECURSIVE: About to call check_unifiable_schemas recursively with {} promoted schemas", promoted_schemas.len());
-        //     return check_unifiable_schemas(&promoted_schemas, path, config);
         } else {
             debug!(config, "{}: Not all schemas are scalars", path);
             for (i, schema) in schemas.iter().enumerate() {

--- a/genson-core/src/schema/map_inference/unification.rs
+++ b/genson-core/src/schema/map_inference/unification.rs
@@ -347,14 +347,14 @@ pub(crate) fn check_unifiable_schemas(
     path: &str,
     config: &SchemaInferenceConfig,
 ) -> Option<Value> {
-    debug!(
+    debug_verbose!(
         config,
         "=== check_unifiable_schemas called with path='{}' and {} schemas:",
         path,
         schemas.len()
     );
     for (i, schema) in schemas.iter().enumerate() {
-        debug!(
+        debug_verbose!(
             config,
             "  Schema[{}]: {}",
             i,

--- a/genson-core/src/schema/map_inference/unification.rs
+++ b/genson-core/src/schema/map_inference/unification.rs
@@ -220,6 +220,7 @@ fn unify_scalar_schemas(
     config: &SchemaInferenceConfig,
 ) -> Option<Value> {
     if schemas.is_empty() {
+        debug!(config, "Empty schema at {}", path);
         return None;
     }
 
@@ -299,6 +300,21 @@ pub(crate) fn check_unifiable_schemas(
     path: &str,
     config: &SchemaInferenceConfig,
 ) -> Option<Value> {
+    debug!(
+        config,
+        "=== check_unifiable_schemas called with path='{}' and {} schemas:",
+        path,
+        schemas.len()
+    );
+    for (i, schema) in schemas.iter().enumerate() {
+        debug!(
+            config,
+            "  Schema[{}]: {}",
+            i,
+            serde_json::to_string(schema).unwrap_or_default()
+        );
+    }
+
     if schemas.is_empty() {
         debug!(config, "{path}: failed (empty schema list)");
         return None;
@@ -313,6 +329,37 @@ pub(crate) fn check_unifiable_schemas(
                 "{}: All schemas are scalars, attempting scalar unification", path
             );
             return unify_scalar_schemas(schemas, path, config);
+        // } else if config.wrap_scalars && schemas.iter().any(is_scalar_schema) && schemas.iter().any(is_object_schema) {
+        //     // Mixed scalar+object schemas with wrap_scalars enabled - promote scalars then proceed
+        //     debug!(config, "{}: Mixed scalar+object schemas, proceeding with scalar promotion", path);
+        //
+        //     let field_name = path.split('.').last().unwrap_or("");
+        //     let mut promoted_schemas = Vec::new();
+        //
+        //     for schema in schemas {
+        //         if is_scalar_schema(schema) {
+        //             if let Some(scalar_type) = get_scalar_type_name(schema) {
+        //                 let wrapped_key = make_promoted_scalar_key(field_name, &scalar_type);
+        //                 let promoted = json!({
+        //                     "type": "object",
+        //                     "properties": {
+        //                         wrapped_key.clone(): schema.clone()
+        //                     }
+        //                 });
+        //                 debug!(config, "{}: Promoted scalar {} to object with key {}", path, scalar_type, wrapped_key);
+        //                 promoted_schemas.push(promoted);
+        //             } else {
+        //                 debug!(config, "{}: Failed to get scalar type for promotion", path);
+        //                 return None;
+        //             }
+        //         } else {
+        //             promoted_schemas.push(schema.clone());
+        //         }
+        //     }
+        //
+        //     // Recursively call with promoted schemas (now all objects)
+        //     debug!(config, "RECURSIVE: About to call check_unifiable_schemas recursively with {} promoted schemas", promoted_schemas.len());
+        //     return check_unifiable_schemas(&promoted_schemas, path, config);
         } else {
             debug!(config, "{}: Not all schemas are scalars", path);
             for (i, schema) in schemas.iter().enumerate() {
@@ -325,8 +372,8 @@ pub(crate) fn check_unifiable_schemas(
                     );
                 }
             }
+            return None;
         }
-        return None;
     }
 
     let mut all_fields = ordermap::OrderMap::new();

--- a/genson-core/src/tests/unification.rs
+++ b/genson-core/src/tests/unification.rs
@@ -100,7 +100,6 @@ fn test_anyof_unification() {
     assert!(anyof_schema.get("properties").is_some(), "Should have properties after unification");
 }
 
-#[ignore]
 #[test]
 fn test_scalar_vs_mixed_type_object_unification() {
     let test_data = vec![


### PR DESCRIPTION
There is currently a gap in the coverage which I only noticed when trying to resolve why int and
string record fields were producing "failure to unify" errors in the logs of row 4 of the wikidata
claims fixture.

When I tried to solve it (and walked back in this PR initially) the solution produced side effects
in existing snapshots where fields would get promoted aberrantly (including nesting recursively)

This has to be done very carefully!

- Also improved the interpretability of the unify mixed nullable test with the hex colours to be
  theme map of colour primary/secondary etc
- Failing tests introduced but commented out

**Update** - reintroduced more carefully now with attention to nested case where recursion has to have rewrite operations in order, so a short circuit prevents a schema move before a rewrite