### PR TITLE
Parallelise JSON string prep and schema building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "simd-json 0.13.11",
  "tracing",
  "tracing-subscriber",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ polars-jsonschema-bridge = { path = "polars-jsonschema-bridge", version = "0.4.2
 # Core dependencies
 serde = { features = ["derive"], version = "1.0" }
 serde_json = { features = ["preserve_order"], version = "1.0" }
+xxhash-rust = { features = ["xxh64"], version = "0.8.15" }
 # Polars integration dependencies  
 polars = { default-features = false, features = [
   "dtype-full",

--- a/examples/test_parallel.rs
+++ b/examples/test_parallel.rs
@@ -1,0 +1,74 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! genson-core = { path = "../genson-core", features = ["avro"] }
+//! serde_json = "1.0"
+//! ```
+
+use genson_core::{infer_json_schema_from_strings, SchemaInferenceConfig};
+use genson_core::normalise::{normalise_values, NormaliseConfig, MapEncoding};
+
+fn main() {
+    // Simulate what the Python extension does with 30 rows
+    let json_strings: Vec<String> = std::fs::read_to_string("../genson-cli/tests/data/claims_fixture_x30.jsonl")
+        .expect("Failed to read file")
+        .lines()
+        .take(5)
+        .map(String::from)
+        .collect();
+
+    println!("Testing with {} JSON strings", json_strings.len());
+
+    // FIRST PASS: Infer schema from original JSON
+    let config = SchemaInferenceConfig {
+        ignore_outer_array: true,
+        delimiter: None,
+        schema_uri: Some("AUTO".to_string()),
+        map_threshold: 0,
+        map_max_required_keys: None,
+        unify_maps: true,
+        no_unify: std::collections::HashSet::new(),
+        force_field_types: std::collections::HashMap::new(),
+        wrap_scalars: true,
+        avro: true,
+        wrap_root: Some("claims".to_string()),
+        no_root_map: true,
+        debug: false,
+        verbosity: genson_core::DebugVerbosity::Normal,
+    };
+
+    println!("\n=== FIRST INFERENCE (original JSON) ===");
+    let schema_result = infer_json_schema_from_strings(&json_strings, config.clone())
+        .expect("Schema inference failed");
+
+    println!("Schema inferred, {} objects processed", schema_result.processed_count);
+
+    // NORMALIZATION PASS
+    println!("\n=== NORMALIZATION ===");
+    let norm_config = NormaliseConfig {
+        empty_as_null: true,
+        coerce_string: false,
+        map_encoding: MapEncoding::KeyValueEntries,
+        wrap_root: Some("claims".to_string()),
+    };
+
+    let mut normalized_jsons = Vec::new();
+    for json_str in &json_strings {
+        let val: serde_json::Value = serde_json::from_str(json_str)
+            .expect("Failed to parse JSON");
+        let normed = normalise_values(vec![val], &schema_result.schema, &norm_config)
+            .pop()
+            .unwrap();
+        normalized_jsons.push(serde_json::to_string(&normed).unwrap());
+    }
+
+    println!("Normalized {} JSON strings", normalized_jsons.len());
+
+    // SECOND PASS: Infer schema from normalized JSON (for decode=True)
+    println!("\n=== SECOND INFERENCE (normalized JSON) ===");
+    let schema_result2 = infer_json_schema_from_strings(&normalized_jsons, config)
+        .expect("Second schema inference failed");
+
+    println!("Second schema inferred, {} objects processed", schema_result2.processed_count);
+    println!("\n=== COMPLETE ===");
+}

--- a/examples/test_parallel.rs
+++ b/examples/test_parallel.rs
@@ -13,7 +13,9 @@ fn main() {
     let json_strings: Vec<String> = std::fs::read_to_string("../genson-cli/tests/data/claims_fixture_x30.jsonl")
         .expect("Failed to read file")
         .lines()
-        .take(5)
+        // .take(5)
+        // .cycle()
+        .take(30)
         .map(String::from)
         .collect();
 

--- a/genson-core/Cargo.toml
+++ b/genson-core/Cargo.toml
@@ -2,6 +2,7 @@
 # genson-rs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+xxhash-rust = { workspace = true }
 
 # Optional dependencies
 avrotize = { optional = true, version = "0.1.1" }

--- a/genson-core/src/schema.rs
+++ b/genson-core/src/schema.rs
@@ -1,6 +1,6 @@
 use crate::debug;
 use crate::genson_rs::{build_json_schema, get_builder, BuildConfig};
-use rayon::prelude::*;
+// use rayon::prelude::*;
 use serde::de::Error as DeError;
 use serde::Deserialize;
 use serde_json::Value;

--- a/genson-core/src/schema.rs
+++ b/genson-core/src/schema.rs
@@ -214,12 +214,16 @@ pub fn infer_json_schema_from_strings(
             };
 
             let mut processed_count = 0;
+            eprintln!("Starting preparation loop ({})", current_time_hms());
 
             // Process each JSON string
             for (i, json_str) in json_strings.iter().enumerate() {
                 eprintln!("PROCESSING JSON STRING {}", i);
 
+                let prep_start = std::time::Instant::now();
                 let prepared_json = prepare_json_string(json_str, i, &config)?;
+                let prep_elapsed = prep_start.elapsed();
+                eprintln!("  Preparation took: {:?}", prep_elapsed);
 
                 if prepared_json.is_empty() {
                     continue;
@@ -228,7 +232,11 @@ pub fn infer_json_schema_from_strings(
                 let mut bytes = prepared_json.as_bytes().to_vec();
 
                 // Build schema incrementally - this is where panics happen
+                let build_start = std::time::Instant::now();
                 let _schema = build_json_schema(&mut builder, &mut bytes, &build_config);
+                let build_elapsed = build_start.elapsed();
+                eprintln!("  Schema building took: {:?}", build_elapsed);
+
                 processed_count += 1;
             }
 


### PR DESCRIPTION
- **refactor: factor out JSON prep; log time of steps and JSON string passes**
- **chore: log the elapsed time**
- **refactor: dedicated sequential JSON string processing function**
- **test: repro example for development**
- **test(fixture): x30 JSONL fixture**
- **chore: temporarily revert rayon**
- **feat: introduce parallelism (schema building)**
