### PR TITLE
perf: profile the peak RSS and move other profile logs to verbose

### DIFF
--- a/genson-core/src/schema/core.rs
+++ b/genson-core/src/schema/core.rs
@@ -60,6 +60,13 @@ impl SchemaInferenceConfig {
         }
     }
 
+    pub(crate) fn profile_verbose(&self, args: std::fmt::Arguments) {
+        if self.profile && matches!(self.verbosity, DebugVerbosity::Verbose) {
+            let message = format!("{}", args);
+            eprintln!("{}", message);
+        }
+    }
+
     pub(crate) fn debug(&self, args: std::fmt::Arguments) {
         if self.debug {
             let message = format!("{}", args);
@@ -128,6 +135,13 @@ impl Default for SchemaInferenceConfig {
 macro_rules! profile {
     ($cfg:expr, $($arg:tt)*) => {
         $cfg.profile(format_args!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! profile_verbose {
+    ($cfg:expr, $($arg:tt)*) => {
+        $cfg.profile_verbose(format_args!($($arg)*))
     };
 }
 

--- a/genson-core/src/schema/map_inference.rs
+++ b/genson-core/src/schema/map_inference.rs
@@ -1,6 +1,6 @@
 // genson-core/src/schema/map_inference.rs
-use crate::debug;
 use crate::schema::core::SchemaInferenceConfig;
+use crate::{debug, profile_verbose};
 use rayon::prelude::*;
 use serde_json::Value;
 mod unification;
@@ -18,13 +18,12 @@ fn process_properties_parallel<F>(
     F: Fn(&str, &mut Value) + Send + Sync,
 {
     if props_obj.len() >= PARALLEL_PROP_THRESHOLD {
-        if config.profile {
-            eprintln!(
-                "Parallelising: {} properties ({})",
-                props_obj.len(),
-                current_time_hms()
-            );
-        }
+        profile_verbose!(
+            config,
+            "Parallelising: {} properties ({})",
+            props_obj.len(),
+            current_time_hms()
+        );
         // Extract entries, process in parallel, reconstruct map
         let entries: Vec<_> = std::mem::take(props_obj).into_iter().collect();
         let processed: Vec<(String, Value)> = entries


### PR DESCRIPTION
The peak RSS can be seen around the builder schemas. While this makes it very fast, it's not clear
whether it should be moderated to avoid spikes (or if the high RSS seen in the Python extension with
many rows comes from the same as the Rust library with a few rows). Passing the `profile` flag now
gives fewer log lines, and the RSS is made visible with lines like:

```
Starting parallel preparation and building (18:27:24.3)                                                                                                                                                                                                                                                                                                                    
📊 RSS before parallel processing: 108.95 MB                                                                                                                                                                                                                                                                                                                               
📊 RSS after collecting 30 individual_builders: 5.94 GB                                                                                                                              
Merging schemas in batch (18:27:28.2)                                                                                                                                                
📊 RSS after extracting 30 schemas: 6.59 GB                        
Merging 30 unique schemas in batch (18:27:31.4)
📊 RSS after builder.add_schemas: 4.03 GB
Batch merge complete (18:27:32.7)
Rewriting objects (18:27:33.7)                                                            
...
Starting parallel preparation and building (18:27:36.9)
📊 RSS before parallel processing: 2.55 GB
📊 RSS after collecting 30 individual_builders: 857.95 MB
Merging schemas in batch (18:27:37.7)
📊 RSS after extracting 28 schemas: 803.47 MB
Merging 28 unique schemas in batch (18:27:37.7)
📊 RSS after builder.add_schemas: 745.89 MB
Batch merge complete (18:27:37.7)
```
