### PR TITLE
parquet io in core and CLI

### DIFF
--- a/genson-core/src/lib.rs
+++ b/genson-core/src/lib.rs
@@ -4,6 +4,8 @@ compile_error!("genson-core requires panic=unwind to catch genson-rs panics. Set
 pub mod genson_rs;
 #[cfg(feature = "avro")]
 pub mod normalise;
+#[cfg(feature = "parquet")]
+pub mod parquet;
 pub mod schema;
 
 // Re-export commonly used items

--- a/genson-core/src/parquet.rs
+++ b/genson-core/src/parquet.rs
@@ -1,0 +1,136 @@
+//! Parquet file I/O for reading and writing string columns
+
+use arrow::array::{Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use std::fs::File;
+use std::sync::Arc;
+
+/// Read a string column from a Parquet file
+///
+/// # Arguments
+/// * `path` - Path to the Parquet file
+/// * `column_name` - Name of the string column to extract
+///
+/// # Returns
+/// Vector of strings from the specified column (nulls are skipped)
+///
+/// # Errors
+/// Returns error if:
+/// - File cannot be opened
+/// - Column doesn't exist
+/// - Column is not a string type (Utf8 or LargeUtf8)
+pub fn read_string_column(path: &str, column_name: &str) -> Result<Vec<String>, String> {
+    let file =
+        File::open(path).map_err(|e| format!("Failed to open Parquet file '{}': {}", path, e))?;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| format!("Failed to read Parquet file '{}': {}", path, e))?;
+
+    // Find column and verify it's a string type
+    let schema = builder.schema();
+    let (column_index, field) = schema.column_with_name(column_name).ok_or_else(|| {
+        let available: Vec<_> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        format!(
+            "Column '{}' not found in Parquet file. Available columns: {}",
+            column_name,
+            available.join(", ")
+        )
+    })?;
+
+    // Ensure it's actually a string column
+    match field.data_type() {
+        DataType::Utf8 | DataType::LargeUtf8 => {}
+        other => {
+            return Err(format!(
+                "Column '{}' has type {:?}, but must be Utf8 or LargeUtf8 (string)",
+                column_name, other
+            ));
+        }
+    }
+
+    let reader = builder
+        .build()
+        .map_err(|e| format!("Failed to create Parquet reader: {}", e))?;
+
+    let mut strings = Vec::new();
+
+    // Process all record batches
+    for batch_result in reader {
+        let batch = batch_result.map_err(|e| format!("Failed to read record batch: {}", e))?;
+
+        let column = batch.column(column_index);
+
+        // Downcast to StringArray - this should always succeed given our type check
+        let string_array = column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| "Failed to downcast column to StringArray".to_string())?;
+
+        // Extract non-null values
+        for i in 0..string_array.len() {
+            if !string_array.is_null(i) {
+                strings.push(string_array.value(i).to_string());
+            }
+        }
+    }
+
+    Ok(strings)
+}
+
+/// Write strings to a Parquet file as a single string column
+///
+/// # Arguments
+/// * `path` - Output path for the Parquet file
+/// * `column_name` - Name for the string column
+/// * `strings` - Vector of strings to write
+///
+/// # Errors
+/// Returns error if file cannot be written or Arrow conversion fails
+pub fn write_string_column(
+    path: &str,
+    column_name: &str,
+    strings: Vec<String>,
+) -> Result<(), String> {
+    // Create schema with single nullable string column
+    let schema = Schema::new(vec![Field::new(column_name, DataType::Utf8, true)]);
+    let schema_ref = Arc::new(schema.clone());
+
+    // Convert Vec<String> to Arrow StringArray
+    let string_array = StringArray::from(strings);
+
+    // Create RecordBatch
+    let batch = RecordBatch::try_new(schema_ref.clone(), vec![Arc::new(string_array)])
+        .map_err(|e| format!("Failed to create RecordBatch: {}", e))?;
+
+    // Open file for writing
+    let file = File::create(path)
+        .map_err(|e| format!("Failed to create output file '{}': {}", path, e))?;
+
+    // Configure writer properties (can be customized)
+    let props = WriterProperties::builder().build();
+
+    // Create Arrow writer
+    let mut writer = ArrowWriter::try_new(file, schema_ref, Some(props))
+        .map_err(|e| format!("Failed to create Parquet writer: {}", e))?;
+
+    // Write the batch
+    writer
+        .write(&batch)
+        .map_err(|e| format!("Failed to write RecordBatch: {}", e))?;
+
+    // Close and finalize
+    writer
+        .close()
+        .map_err(|e| format!("Failed to close Parquet writer: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    include!("tests/parquet.rs");
+}

--- a/genson-core/src/tests/parquet.rs
+++ b/genson-core/src/tests/parquet.rs
@@ -1,0 +1,35 @@
+// genson-core/src/tests/parquet.rs
+use super::*;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_write_and_read_roundtrip() {
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_str().unwrap();
+
+    let test_strings = vec![
+        r#"{"name": "Alice", "age": 30}"#.to_string(),
+        r#"{"name": "Bob", "age": 25}"#.to_string(),
+    ];
+
+    // Write
+    write_string_column(path, "json_data", test_strings.clone()).unwrap();
+
+    // Read back
+    let result = read_string_column(path, "json_data").unwrap();
+
+    assert_eq!(result, test_strings);
+}
+
+#[test]
+fn test_read_nonexistent_column() {
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_str().unwrap();
+
+    let test_strings = vec!["test".to_string()];
+    write_string_column(path, "data", test_strings).unwrap();
+
+    let result = read_string_column(path, "wrong_name");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("not found"));
+}


### PR DESCRIPTION
- **chore: rebase**
- **fix(clippy): trivial reference**

The same great taste of polars-genson now available for Parquet files

```sh
louis 🌟 ~/dev/polars-genson $ ./target/debug/genson-cli --map-threshold 0 --unify-maps --wrap-root claims --pq-column claims ./polars-genson-py/tests/data/claims_fixture_x4.parquet
{                                                                                                                              
  "$schema": "http://json-schema.org/schema#",                                                                                                                                                                                                                
  "properties": {                                                                                                              
    "claims": {                                                                                                                                                                                                                                               
      "type": "object",                                                                                                        
      "additionalProperties": {                                                                                                
        "type": "array",                                                                                                                                                                                                                                      
        "items": {                                                                                                             
          "type": "object",                                                                                                    
          "properties": {     
...
```