### PR TITLE
feat: use anstream for all (e)println calls to make them pipeable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
 name = "genson-cli"
 version = "0.6.5"
 dependencies = [
+ "anstream",
  "assert_cmd",
  "genson-core",
  "insta",
@@ -1252,6 +1253,7 @@ dependencies = [
 name = "genson-core"
 version = "0.6.5"
 dependencies = [
+ "anstream",
  "arrow",
  "avrotize",
  "crustrace",
@@ -2537,6 +2539,7 @@ dependencies = [
 name = "polars-genson-py"
 version = "0.1.0"
 dependencies = [
+ "anstream",
  "genson-core",
  "polars",
  "polars-arrow",
@@ -2615,6 +2618,7 @@ dependencies = [
 name = "polars-jsonschema-bridge"
 version = "0.6.0"
 dependencies = [
+ "anstream",
  "eyre",
  "insta",
  "polars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ polars-genson-py = { path = "polars-genson-py", version = "0.1.0" }
 polars-jsonschema-bridge = { path = "polars-jsonschema-bridge", version = "0.6.0" }
 
 # Core dependencies
+anstream = "0.6"
 serde = { features = ["derive"], version = "1.0" }
 serde_json = { features = ["preserve_order"], version = "1.0" }
 xxhash-rust = { features = ["xxh64"], version = "0.8.15" }

--- a/genson-cli/Cargo.toml
+++ b/genson-cli/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+anstream = { workspace = true }
 genson-core = { features = ["avro", "parquet"], workspace = true }
 serde_json = { workspace = true }
 

--- a/genson-cli/src/main.rs
+++ b/genson-cli/src/main.rs
@@ -245,67 +245,87 @@ fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
         if config.delimiter == Some(b'\n') {
             // print one line per row
             for v in normalised {
-                println!("{}", serde_json::to_string(&v)?);
+                anstream::println!("{}", serde_json::to_string(&v)?);
             }
         } else {
-            println!("{}", serde_json::to_string_pretty(&normalised)?);
+            anstream::println!("{}", serde_json::to_string_pretty(&normalised)?);
         }
     } else {
         // Pretty-print the schema
-        println!("{}", serde_json::to_string_pretty(&result.schema)?);
+        anstream::println!("{}", serde_json::to_string_pretty(&result.schema)?);
     }
 
-    eprintln!("Processed {} JSON object(s)", result.processed_count);
+    anstream::eprintln!("Processed {} JSON object(s)", result.processed_count);
     Ok(())
 }
 
 fn print_help() {
-    println!("genson-cli - JSON schema inference tool");
-    println!();
-    println!("USAGE:");
-    println!("    genson-cli [OPTIONS] [FILE]");
-    println!();
-    println!("ARGS:");
-    println!("    <FILE>    Input JSON file (reads from stdin if not provided)");
-    println!();
-    println!("OPTIONS:");
-    println!("    -h, --help            Print this help message");
-    println!("    --no-ignore-array     Don't treat top-level arrays as object streams");
-    println!("    --ndjson              Treat input as newline-delimited JSON");
-    println!("    --avro                Output Avro schema instead of JSON Schema");
-    println!("    --normalise           Normalise the input data against the inferred schema");
-    println!("    --coerce-strings      Coerce numeric/boolean strings to schema type during normalisation");
-    println!("    --keep-empty          Keep empty arrays/maps instead of turning them into nulls");
-    println!("    --map-threshold <N>   Treat objects with >N keys as map candidates (default 20)");
-    println!(
+    anstream::println!("genson-cli - JSON schema inference tool");
+    anstream::println!();
+    anstream::println!("USAGE:");
+    anstream::println!("    genson-cli [OPTIONS] [FILE]");
+    anstream::println!();
+    anstream::println!("ARGS:");
+    anstream::println!("    <FILE>    Input JSON file (reads from stdin if not provided)");
+    anstream::println!();
+    anstream::println!("OPTIONS:");
+    anstream::println!("    -h, --help            Print this help message");
+    anstream::println!("    --no-ignore-array     Don't treat top-level arrays as object streams");
+    anstream::println!("    --ndjson              Treat input as newline-delimited JSON");
+    anstream::println!("    --avro                Output Avro schema instead of JSON Schema");
+    anstream::println!(
+        "    --normalise           Normalise the input data against the inferred schema"
+    );
+    anstream::println!("    --coerce-strings      Coerce numeric/boolean strings to schema type during normalisation");
+    anstream::println!(
+        "    --keep-empty          Keep empty arrays/maps instead of turning them into nulls"
+    );
+    anstream::println!(
+        "    --map-threshold <N>   Treat objects with >N keys as map candidates (default 20)"
+    );
+    anstream::println!(
         "    --map-max-rk <N>      Maximum required keys for Map inference (default: no limit)"
     );
-    println!("    --map-max-required-keys <N>");
-    println!("    --unify-maps          Enable unification of compatible record schemas into maps");
-    println!("                          Same as --map-max-rk");
-    println!("    --no-unify <fields>   Exclude fields from record unification (comma-separated)");
-    println!("                          Example: --no-unify qualifiers,references");
-    println!("    --force-type k:v,...  Force field(s) to 'map' or 'record'");
-    println!("                          Example: --force-type labels:map,claims:record");
-    println!("    --force-scalar-promotion <fields>");
-    println!("                          Always promote these fields to wrapped scalars (comma-separated)");
-    println!("                          Example: --force-scalar-promotion precision,datavalue");
-    println!("    --map-encoding <mode> Choose map encoding (mapping|entries|kv)");
-    println!("                          mapping = Avro/JSON object (shared dict)");
-    println!("                          entries = list of single-entry objects (individual dicts)");
-    println!("                          kv      = list of {{key,value}} objects");
-    println!("    --no-wrap-scalars     Disable scalar promotion (keep raw scalar types)");
-    println!("    --wrap-root <field>   Wrap top-level schema under this required field");
-    println!("    --root-map            Allow document root to become a map");
-    println!("    --max-builders <N>    Maximum schema builders to create in parallel at once");
-    println!("                          Lower values reduce peak memory (default: unlimited)");
-    println!("    --debug               Enable debug output during schema inference");
-    println!("    --profile             Enable profiling output during schema inference");
-    println!();
-    println!("EXAMPLES:");
-    println!("    genson-cli data.json");
-    println!("    echo '{{\"name\": \"test\"}}' | genson-cli");
-    println!("    genson-cli --ndjson multi-line.jsonl");
+    anstream::println!("    --map-max-required-keys <N>");
+    anstream::println!(
+        "    --unify-maps          Enable unification of compatible record schemas into maps"
+    );
+    anstream::println!("                          Same as --map-max-rk");
+    anstream::println!(
+        "    --no-unify <fields>   Exclude fields from record unification (comma-separated)"
+    );
+    anstream::println!("                          Example: --no-unify qualifiers,references");
+    anstream::println!("    --force-type k:v,...  Force field(s) to 'map' or 'record'");
+    anstream::println!("                          Example: --force-type labels:map,claims:record");
+    anstream::println!("    --force-scalar-promotion <fields>");
+    anstream::println!("                          Always promote these fields to wrapped scalars (comma-separated)");
+    anstream::println!(
+        "                          Example: --force-scalar-promotion precision,datavalue"
+    );
+    anstream::println!("    --map-encoding <mode> Choose map encoding (mapping|entries|kv)");
+    anstream::println!("                          mapping = Avro/JSON object (shared dict)");
+    anstream::println!(
+        "                          entries = list of single-entry objects (individual dicts)"
+    );
+    anstream::println!("                          kv      = list of {{key,value}} objects");
+    anstream::println!(
+        "    --no-wrap-scalars     Disable scalar promotion (keep raw scalar types)"
+    );
+    anstream::println!("    --wrap-root <field>   Wrap top-level schema under this required field");
+    anstream::println!("    --root-map            Allow document root to become a map");
+    anstream::println!(
+        "    --max-builders <N>    Maximum schema builders to create in parallel at once"
+    );
+    anstream::println!(
+        "                          Lower values reduce peak memory (default: unlimited)"
+    );
+    anstream::println!("    --debug               Enable debug output during schema inference");
+    anstream::println!("    --profile             Enable profiling output during schema inference");
+    anstream::println!();
+    anstream::println!("EXAMPLES:");
+    anstream::println!("    genson-cli data.json");
+    anstream::println!("    echo '{{\"name\": \"test\"}}' | genson-cli");
+    anstream::println!("    genson-cli --ndjson multi-line.jsonl");
 }
 
 #[cfg(test)]
@@ -316,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_cli_with_invalid_json_unit() {
-        println!("=== Unit test calling CLI logic directly ===");
+        anstream::println!("=== Unit test calling CLI logic directly ===");
 
         // Create a temp file with invalid JSON
         let invalid_json = r#"{"invalid": json}"#;
@@ -333,7 +353,7 @@ mod tests {
         let json_strings = vec![invalid_json.to_string()];
         let result = infer_json_schema(&json_strings, Some(SchemaInferenceConfig::default()));
 
-        println!("Result: {:?}", result);
+        anstream::println!("Result: {:?}", result);
 
         match result {
             Ok(schema_result) => {
@@ -343,7 +363,7 @@ mod tests {
                 );
             }
             Err(error_msg) => {
-                println!("✅ Got error in unit test: {}", error_msg);
+                anstream::println!("✅ Got error in unit test: {}", error_msg);
                 // Check for the key parts of the error message instead of exact match
                 assert!(error_msg.contains("Invalid JSON input"));
                 assert!(error_msg.contains("line"));
@@ -353,19 +373,19 @@ mod tests {
 
     #[test]
     fn test_genson_core_directly() {
-        println!("=== Direct test of genson-core function ===");
+        anstream::println!("=== Direct test of genson-core function ===");
 
         let json_strings = vec![r#"{"invalid": json}"#.to_string()];
         let result = infer_json_schema(&json_strings, Some(SchemaInferenceConfig::default()));
 
-        println!("Direct result: {:?}", result);
+        anstream::println!("Direct result: {:?}", result);
 
         match result {
             Ok(schema_result) => {
                 panic!("Expected error but got success: {:?}", schema_result);
             }
             Err(error_msg) => {
-                println!("✅ Got expected error: {}", error_msg);
+                anstream::println!("✅ Got expected error: {}", error_msg);
                 // Check for the key parts of the error message instead of exact match
                 assert!(error_msg.contains("Invalid JSON input"));
                 assert!(error_msg.contains("line"));
@@ -398,7 +418,7 @@ mod tests {
         };
         let normalised = normalise_values(values, &result.schema, &norm_cfg);
 
-        println!(
+        anstream::println!(
             "Normalised with empty_as_null: {}",
             serde_json::to_string(&normalised).unwrap()
         );
@@ -430,7 +450,7 @@ mod tests {
         };
         let normalised = normalise_values(values, &result.schema, &norm_cfg);
 
-        println!(
+        anstream::println!(
             "Normalised with keep_empty: {}",
             serde_json::to_string(&normalised).unwrap()
         );

--- a/genson-core/Cargo.toml
+++ b/genson-core/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+anstream = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 xxhash-rust = { workspace = true }

--- a/genson-core/src/genson_rs/strategy/object.rs
+++ b/genson-core/src/genson_rs/strategy/object.rs
@@ -304,8 +304,8 @@ mod tests {
 
         let keys1: Vec<_> = strat1.properties.keys().collect();
         let keys2: Vec<_> = strat2.properties.keys().collect();
-        println!("keys1 = {:?}", keys1);
-        println!("keys2 = {:?}", keys2);
+        anstream::println!("keys1 = {:?}", keys1);
+        anstream::println!("keys2 = {:?}", keys2);
 
         // The keys are the same set, but in different order.
         // With OrderMap, properties != properties because order matters.

--- a/genson-core/src/schema.rs
+++ b/genson-core/src/schema.rs
@@ -294,7 +294,7 @@ fn process_json_strings_parallel(
 
     if config.profile {
         if let Some(rss) = get_rss_bytes() {
-            eprintln!("📊 RSS before parallel processing: {}", format_bytes(rss));
+            anstream::eprintln!("📊 RSS before parallel processing: {}", format_bytes(rss));
         }
     }
 
@@ -311,7 +311,7 @@ fn process_json_strings_parallel(
 
         if config.profile {
             if let Some(rss) = get_rss_bytes() {
-                eprintln!("📊 RSS before chunk {}: {}", chunk_idx, format_bytes(rss));
+                anstream::eprintln!("📊 RSS before chunk {}: {}", chunk_idx, format_bytes(rss));
             }
         }
 
@@ -360,7 +360,7 @@ fn process_json_strings_parallel(
 
         if config.profile {
             if let Some(rss) = get_rss_bytes() {
-                eprintln!("📊 RSS after collecting chunk: {}", format_bytes(rss));
+                anstream::eprintln!("📊 RSS after collecting chunk: {}", format_bytes(rss));
             }
         }
 
@@ -383,7 +383,7 @@ fn process_json_strings_parallel(
 
         if config.profile {
             if let Some(rss) = get_rss_bytes() {
-                eprintln!("📊 RSS after merging chunk: {}", format_bytes(rss));
+                anstream::eprintln!("📊 RSS after merging chunk: {}", format_bytes(rss));
             }
         }
     }

--- a/genson-core/src/schema/core.rs
+++ b/genson-core/src/schema/core.rs
@@ -64,28 +64,28 @@ impl SchemaInferenceConfig {
     pub(crate) fn profile(&self, args: std::fmt::Arguments) {
         if self.profile {
             let message = format!("{}", args);
-            eprintln!("{}", message);
+            anstream::eprintln!("{}", message);
         }
     }
 
     pub(crate) fn profile_verbose(&self, args: std::fmt::Arguments) {
         if self.profile && matches!(self.verbosity, DebugVerbosity::Verbose) {
             let message = format!("{}", args);
-            eprintln!("{}", message);
+            anstream::eprintln!("{}", message);
         }
     }
 
     pub(crate) fn debug(&self, args: std::fmt::Arguments) {
         if self.debug {
             let message = format!("{}", args);
-            eprintln!("{}", self.maybe_truncate(message));
+            anstream::eprintln!("{}", self.maybe_truncate(message));
         }
     }
 
     pub(crate) fn debug_verbose(&self, args: std::fmt::Arguments) {
         if self.debug && matches!(self.verbosity, DebugVerbosity::Verbose) {
             let message = format!("{}", args);
-            eprintln!("{}", self.maybe_truncate(message));
+            anstream::eprintln!("{}", self.maybe_truncate(message));
         }
     }
 

--- a/genson-core/src/schema/map_inference.rs
+++ b/genson-core/src/schema/map_inference.rs
@@ -397,7 +397,7 @@ pub(crate) fn rewrite_objects(
             // Copy out child schema shapes
             let child_schemas: Vec<&Value> = props.values().collect();
             if config.profile && child_schemas.len() > 50 {
-                eprintln!("Collected {} schemas", child_schemas.len());
+                anstream::eprintln!("Collected {} schemas", child_schemas.len());
             }
 
             // Detect map-of-records only if:
@@ -513,7 +513,7 @@ pub(crate) fn rewrite_objects(
                 } else if config.unify_maps {
                     debug!(config, "Schemas not homogeneous, attempting unification");
                     if config.profile && normalised_schemas.len() > 50 {
-                        eprintln!(
+                        anstream::eprintln!(
                             "Unification of {} heterogeneous schemas beginning...",
                             normalised_schemas.len()
                         );
@@ -564,7 +564,7 @@ pub(crate) fn rewrite_objects(
                                     }));
                                 }
                                 if config.profile && child_schemas.len() > 50 {
-                                    eprintln!(
+                                    anstream::eprintln!(
                                         "Unification of {} item schemas took {:?}",
                                         child_schemas.len(),
                                         unify_start.elapsed()
@@ -582,7 +582,7 @@ pub(crate) fn rewrite_objects(
                                     config,
                                 );
                                 if config.profile && child_schemas.len() > 50 {
-                                    eprintln!(
+                                    anstream::eprintln!(
                                         "Unification of {} child schemas took {:?}",
                                         child_schemas.len(),
                                         unify_start.elapsed()
@@ -593,7 +593,7 @@ pub(crate) fn rewrite_objects(
                     }
                 }
                 if config.profile && normalised_schemas.len() > 50 {
-                    eprintln!(
+                    anstream::eprintln!(
                         "Homogeneity check on {} schemas took {:?}",
                         normalised_schemas.len(),
                         homog_start.elapsed()

--- a/genson-core/src/schema/map_inference/unification.rs
+++ b/genson-core/src/schema/map_inference/unification.rs
@@ -753,7 +753,7 @@ fn unify_record_schemas(
     }
 
     if config.profile && schemas.len() > 50 {
-        eprintln!("  Merge loop took {:?}", merge_start.elapsed());
+        anstream::eprintln!("  Merge loop took {:?}", merge_start.elapsed());
     }
 
     let total_schemas = schemas.len();

--- a/polars-genson-py/Cargo.toml
+++ b/polars-genson-py/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+anstream = { workspace = true }
 genson-core = { features = ["avro", "parquet"], workspace = true }
 polars.workspace = true
 polars-arrow.workspace = true

--- a/polars-genson-py/src/expressions.rs
+++ b/polars-genson-py/src/expressions.rs
@@ -179,13 +179,14 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
     }
 
     if kwargs.debug {
-        eprintln!("DEBUG: Processing {} JSON strings", json_strings.len());
-        eprintln!(
+        anstream::eprintln!("DEBUG: Processing {} JSON strings", json_strings.len());
+        anstream::eprintln!(
             "DEBUG: Config: ignore_outer_array={}, ndjson={}",
-            kwargs.ignore_outer_array, kwargs.ndjson
+            kwargs.ignore_outer_array,
+            kwargs.ndjson
         );
         for (i, json_str) in json_strings.iter().take(3).enumerate() {
-            eprintln!("DEBUG: Sample JSON {}: {}", i + 1, json_str);
+            anstream::eprintln!("DEBUG: Sample JSON {}: {}", i + 1, json_str);
         }
     }
 
@@ -228,7 +229,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
         match result {
             Ok(Ok(schema_json)) => {
                 if kwargs.debug {
-                    eprintln!("DEBUG: Successfully generated merged schema");
+                    anstream::eprintln!("DEBUG: Successfully generated merged schema");
                 }
                 Ok(Series::new("schema".into(), vec![schema_json; 1]))
             }
@@ -275,7 +276,7 @@ pub fn infer_json_schema(inputs: &[Series], kwargs: GensonKwargs) -> PolarsResul
         match result {
             Ok(Ok(individual_schemas)) => {
                 if kwargs.debug {
-                    eprintln!(
+                    anstream::eprintln!(
                         "DEBUG: Generated {} individual schemas",
                         individual_schemas.len()
                     );

--- a/polars-genson-py/src/parquet_io.rs
+++ b/polars-genson-py/src/parquet_io.rs
@@ -56,7 +56,7 @@ pub fn infer_from_parquet(
     })?;
 
     if debug {
-        eprintln!(
+        anstream::eprintln!(
             "Read {} JSON strings from column '{}'",
             json_strings.len(),
             column
@@ -104,14 +104,14 @@ pub fn infer_from_parquet(
     })?;
 
     // Print to stderr
-    eprintln!("Processed {} JSON object(s)", result.processed_count);
+    anstream::eprintln!("Processed {} JSON object(s)", result.processed_count);
 
     // Write to file or return
     if let Some(out_path) = output_path {
         std::fs::write(&out_path, &schema_json).map_err(|e| {
             pyo3::exceptions::PyIOError::new_err(format!("Failed to write to {}: {}", out_path, e))
         })?;
-        eprintln!("Schema written to: {}", out_path);
+        anstream::eprintln!("Schema written to: {}", out_path);
         Ok(format!("Schema written to: {}", out_path))
     } else {
         Ok(schema_json)
@@ -169,7 +169,7 @@ pub fn normalise_from_parquet(
         pyo3::exceptions::PyIOError::new_err(format!("Failed to read Parquet: {}", e))
     })?;
 
-    eprintln!(
+    anstream::eprintln!(
         "Read {} JSON strings from column '{}'",
         json_strings.len(),
         column
@@ -203,7 +203,7 @@ pub fn normalise_from_parquet(
         pyo3::exceptions::PyRuntimeError::new_err(format!("Schema inference failed: {}", e))
     })?;
 
-    eprintln!("Processed {} JSON object(s)", result.processed_count);
+    anstream::eprintln!("Processed {} JSON object(s)", result.processed_count);
 
     // Parse values
     let values: Vec<serde_json::Value> = json_strings
@@ -261,9 +261,10 @@ pub fn normalise_from_parquet(
         |e| pyo3::exceptions::PyIOError::new_err(format!("Failed to write Parquet: {}", e)),
     )?;
 
-    eprintln!(
+    anstream::eprintln!(
         "Normalised data written to: {} (column: {})",
-        output_path, col_name
+        output_path,
+        col_name
     );
 
     Ok(())

--- a/polars-genson-py/src/schema.rs
+++ b/polars-genson-py/src/schema.rs
@@ -9,7 +9,7 @@ macro_rules! eprintln_orange {
     ($($arg:tt)*) => {{
         const ORANGE: &str = "\x1b[38;5;202m";
         const RESET: &str = "\x1b[0m";
-        eprintln!("{ORANGE}(🦀) {}{}", format!($($arg)*), RESET);
+        anstream::eprintln!("{ORANGE}(🦀) {}{}", format!($($arg)*), RESET);
     }};
 }
 

--- a/polars-jsonschema-bridge/Cargo.toml
+++ b/polars-jsonschema-bridge/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 version = "0.6.0"
 
 [dependencies]
+anstream = { workspace = true }
 polars.workspace = true
 serde_json.workspace = true
 

--- a/polars-jsonschema-bridge/src/deserialise.rs
+++ b/polars-jsonschema-bridge/src/deserialise.rs
@@ -24,13 +24,13 @@ pub fn schema_to_polars_fields(
     debug: bool,
 ) -> Result<Vec<(String, String)>, PolarsError> {
     if debug {
-        eprintln!("=== Generated Schema ({:?}) ===", format);
-        eprintln!(
+        anstream::eprintln!("=== Generated Schema ({:?}) ===", format);
+        anstream::eprintln!(
             "{}",
             serde_json::to_string_pretty(schema)
                 .unwrap_or_else(|_| "Failed to serialize".to_string())
         );
-        eprintln!("==============================");
+        anstream::eprintln!("==============================");
     }
 
     match format {


### PR DESCRIPTION
Software that uses `println!`/`eprintln!` will panic if the pipe is closed, such as from piping to `grep`/`rg` with the `-q` flag (if a match is found, that will be sufficient for the grep to report the result, so it closes the pipe, but then a program trying to use `println!` will panic if it finds the descriptor is closed)